### PR TITLE
Simplify kern feature generation a bit

### DIFF
--- a/Lib/ufo2ft/kernFeatureWriter.py
+++ b/Lib/ufo2ft/kernFeatureWriter.py
@@ -81,13 +81,10 @@ class KernFeatureWriter(AbstractFeatureWriter):
         lines.append("feature kern {")
         self._addKerning(lines, self.glyphPairKerning)
         if self.leftClassKerning:
-            lines.append("    subtable;")
             self._addKerning(lines, self.leftClassKerning, enum=True)
         if self.rightClassKerning:
-            lines.append("    subtable;")
             self._addKerning(lines, self.rightClassKerning, enum=True)
         if self.classPairKerning:
-            lines.append("    subtable;")
             self._addKerning(lines, self.classPairKerning)
         lines.append("} kern;")
 
@@ -231,27 +228,6 @@ class KernFeatureWriter(AbstractFeatureWriter):
             if nrGlyphs != rGlyphs:
                 self.rightClassKerning[lGlyph, self._liststr(nrGlyphs)] = val
                 del self.rightClassKerning[lGlyph, rClass]
-
-        # remove conflicts in class / class rules
-        for (lClass, rClass), val in list(self.classPairKerning.items()):
-            lGlyphs = leftClasses[lClass]
-            rGlyphs = rightClasses[rClass]
-            nlGlyphs, nrGlyphs = set(), set()
-            for lGlyph in lGlyphs:
-                for rGlyph in rGlyphs:
-                    pair = lGlyph, rGlyph
-                    if pair not in seen:
-                        nlGlyphs.add(lGlyph)
-                        nrGlyphs.add(rGlyph)
-                        seen[pair] = val
-            nlClass, nrClass = lClass, rClass
-            if nlGlyphs != set(lGlyphs):
-                nlClass = self._liststr(sorted(nlGlyphs))
-            if nrGlyphs != set(rGlyphs):
-                nrClass = self._liststr(sorted(nrGlyphs))
-            if nlClass != lClass or nrClass != rClass:
-                self.classPairKerning[nlClass, nrClass] = val
-                del self.classPairKerning[lClass, rClass]
 
     def _addGlyphClasses(self, lines):
         """Add glyph classes for the input font's groups."""


### PR DESCRIPTION
Adding subtables to feature syntax is unnecessary because feaLib will do this itself.

Checking for conflicts in class-to-class rules is unnecessary because conflicts from other rules are considered exceptions and are allowed. In fact, we can probably do without checking for conflicts anywhere (if we're checking already in glyphs2ufo) except that we enumerate class-to-glyph rules, so glyph-to-glyph rules aren't considered exceptions of them. It would be best to do without this enumeration but that seems to cause problems with compilation (this is something to look into).