### PR TITLE
[feaLib] use feaLib's addOpenTypeFeaturesFromString function

### DIFF
--- a/Lib/ufo2ft/makeotfParts.py
+++ b/Lib/ufo2ft/makeotfParts.py
@@ -4,7 +4,7 @@ import os
 import re
 import tempfile
 
-from fontTools.feaLib.builder import addOpenTypeFeatures
+from fontTools.feaLib.builder import addOpenTypeFeaturesFromString
 from fontTools import mtiLib
 
 from ufo2ft.maxContextCalc import maxCtxFont
@@ -181,4 +181,5 @@ class FeatureOTFCompiler(object):
 
         elif self.features.strip():
             feapath = os.path.join(self.font.path, "features.fea")
-            addOpenTypeFeatures(self.outline, feapath, self.features)
+            addOpenTypeFeaturesFromString(self.outline, self.features,
+                                          filename=feapath)


### PR DESCRIPTION
feaLib's API is in constant change. See https://github.com/behdad/fonttools/pull/556

In the latest fontTools HEAD, the function `addOpenTypeFeatures` now takes either a path or a file-like object as the input featurefile.

A new `addOpenTypeFeaturesFromString` was added to parse features from a string -- which is what ufo2ft wants to use. The 'filename' argument is optional in this case, as it's only used for error messages and relative include paths (a bit unusual for a feature files contained inside a UFO folder).