### PR TITLE
Handle case of font.path being None

### DIFF
--- a/Lib/ufo2ft/makeotfParts.py
+++ b/Lib/ufo2ft/makeotfParts.py
@@ -180,6 +180,6 @@ class FeatureOTFCompiler(object):
                     self.outline[tag] = table
 
         elif self.features.strip():
-            feapath = os.path.join(self.font.path, "features.fea")
+            feapath = os.path.join(self.font.path if self.font.path is not None else '', "features.fea")
             addOpenTypeFeaturesFromString(self.outline, self.features,
                                           filename=feapath)


### PR DESCRIPTION
I don't know who typically sets font.path, but for UFO masters coming from glyphs2ufo (which I *don't* save and reload), font.path is None, and I cannot set them either.  So, either create a tmpfile, or use current directory.  Not sure which is best though.