### PR TITLE
Use AFDKO's fallback values for some OS/2 values

### DIFF
--- a/Lib/ufo2ft/fontInfoData.py
+++ b/Lib/ufo2ft/fontInfoData.py
@@ -208,6 +208,18 @@ def postscriptSlantAngleFallback(info):
     """
     return getAttrWithFallback(info, "italicAngle")
 
+def postscriptUnderlineThicknessFallback(info):
+    """Return UPM * 0.05 (50 for 1000 UPM) and warn."""
+    print('WARNING: underline thickness not set in UFO, defaulting to UPM * '
+          '0.05')
+    return info.unitsPerEm * 0.05
+
+def postscriptUnderlinePositionFallback(info):
+    """Return UPM * -0.075 (-75 for 1000 UPM) and warn."""
+    print('WARNING: underline position not set in UFO, defaulting to UPM * '
+          '-0.075')
+    return info.unitsPerEm * -0.075
+
 _postscriptWeightNameOptions = {
     100 : "Thin",
     200 : "Extra-light",
@@ -311,8 +323,6 @@ staticFallbackData = dict(
     openTypeVheaCaretOffset=None,
 
     postscriptUniqueID=None,
-    postscriptUnderlineThickness=50,
-    postscriptUnderlinePosition=-75,
     postscriptIsFixedPitch=False,
     postscriptBlueValues=[],
     postscriptOtherBlues=[],
@@ -355,6 +365,8 @@ specialFallbacks = dict(
     postscriptFontName=postscriptFontNameFallback,
     postscriptFullName=postscriptFullNameFallback,
     postscriptSlantAngle=postscriptSlantAngleFallback,
+    postscriptUnderlineThickness=postscriptUnderlineThicknessFallback,
+    postscriptUnderlinePosition=postscriptUnderlinePositionFallback,
     postscriptWeightName=postscriptWeightNameFallback
 )
 

--- a/Lib/ufo2ft/fontInfoData.py
+++ b/Lib/ufo2ft/fontInfoData.py
@@ -288,7 +288,7 @@ staticFallbackData = dict(
     openTypeOS2CodePageRanges=[],
     openTypeOS2TypoLineGap=200,
     openTypeOS2Type=[2],
-    # let the FDK fallback on these
+
     openTypeOS2SubscriptXSize=None,
     openTypeOS2SubscriptYSize=None,
     openTypeOS2SubscriptXOffset=None,
@@ -311,8 +311,8 @@ staticFallbackData = dict(
     openTypeVheaCaretOffset=None,
 
     postscriptUniqueID=None,
-    postscriptUnderlineThickness=None,
-    postscriptUnderlinePosition=None,
+    postscriptUnderlineThickness=50,
+    postscriptUnderlinePosition=-75,
     postscriptIsFixedPitch=False,
     postscriptBlueValues=[],
     postscriptOtherBlues=[],

--- a/Lib/ufo2ft/outlineOTF.py
+++ b/Lib/ufo2ft/outlineOTF.py
@@ -695,12 +695,8 @@ class OutlineOTFCompiler(OutlineCompiler):
         topDict.isFixedPitch = getAttrWithFallback(info, "postscriptIsFixedPitch")
         topDict.ItalicAngle = getAttrWithFallback(info, "italicAngle")
         underlinePosition = getAttrWithFallback(info, "postscriptUnderlinePosition")
-        if underlinePosition is None:
-            underlinePosition = 0
         topDict.UnderlinePosition = _roundInt(underlinePosition)
         underlineThickness = getAttrWithFallback(info, "postscriptUnderlineThickness")
-        if underlineThickness is None:
-            underlineThickness = 0
         topDict.UnderlineThickness = _roundInt(underlineThickness)
         # populate font matrix
         unitsPerEm = _roundInt(getAttrWithFallback(info, "unitsPerEm"))


### PR DESCRIPTION
Arguably, these should be set with other "special" fallback values in
fontInfoData.py. However, I like having them all together here so it's
obvious that some rely on others (and they need to be set in a
specific order).

The AFDKO code referenced is at:
https://github.com/adobe-type-tools/afdko/blob/master/FDK/Tools/Programs/makeotf/makeotf_lib/source/hotconv/hot.c

Part of https://github.com/googlei18n/ufo2ft/issues/36. (It would also be nice to set unicodeRanges in OS/2. That's a bit harder, especially since the fallback functions in fontInfoData.py only take in a font info object, which doesn't contain any info about glyphs. It seems to me that we need the glyphs to calculate these ranges.)