### PR TITLE
Right-to-left kerning

### DIFF
--- a/Lib/ufo2ft/kernFeatureWriter.py
+++ b/Lib/ufo2ft/kernFeatureWriter.py
@@ -1,4 +1,5 @@
 from __future__ import print_function, division, absolute_import, unicode_literals
+from fontTools.misc.py23 import unichr
 
 import re
 import unicodedata

--- a/Lib/ufo2ft/kernFeatureWriter.py
+++ b/Lib/ufo2ft/kernFeatureWriter.py
@@ -20,7 +20,17 @@ class KernFeatureWriter(object):
     def __init__(self, font):
         self.kerning = dict(font.kerning)
         self.groups = dict(font.groups)
-        self.featxt = font.features.text or ""
+
+        fealines = []
+        if font.features.text:
+            for line in font.features.text.splitlines():
+                comment_start = line.find('#')
+                if comment_start >= 0:
+                    line = line[:comment_start]
+                line = line.strip()
+                if line:
+                    fealines.append(line)
+        self.featxt = '\n'.join(fealines)
 
         # kerning classes found in existing feature text and UFO groups
         self.leftFeaClasses = {}

--- a/Lib/ufo2ft/kernFeatureWriter.py
+++ b/Lib/ufo2ft/kernFeatureWriter.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division, absolute_import, unicode_literals
 from fontTools.misc.py23 import unichr
 
+import collections
 import re
 try:
     import unicodedata2 as unicodedata
@@ -38,8 +39,8 @@ class KernFeatureWriter(object):
                     fealines.append(line)
         self.featxt = '\n'.join(fealines)
 
-        self.ltrScripts = {}
-        self.rtlScripts = {}
+        self.ltrScripts = collections.OrderedDict()
+        self.rtlScripts = collections.OrderedDict()
         for script, lang in re.findall(
                 r'languagesystem\s+([a-z]{4})\s+([A-Z]+|dflt)\s*;',
                 self.featxt):
@@ -286,9 +287,9 @@ class KernFeatureWriter(object):
         of languages.
         """
 
-        for script, langs in sorted(languageSystems.items()):
+        for script, langs in languageSystems.items():
             lines.append("script %s;" % script)
-            for lang in sorted(langs):
+            for lang in langs:
                 lines.append("language %s;" % lang)
                 lines.append("lookup %s;" % lookupName)
 

--- a/Lib/ufo2ft/kernFeatureWriter.py
+++ b/Lib/ufo2ft/kernFeatureWriter.py
@@ -159,10 +159,7 @@ class KernFeatureWriter(object):
         glyphs (the class members minus the offending members).
         """
 
-        leftClasses = dict(self.leftFeaClasses)
-        leftClasses.update(self.leftUfoClasses)
-        rightClasses = dict(self.rightFeaClasses)
-        rightClasses.update(self.rightUfoClasses)
+        leftClasses, rightClasses = self._getClasses(separate=True)
 
         # maintain list of glyph pair rules seen
         seen = dict(self.glyphPairKerning)
@@ -211,6 +208,20 @@ class KernFeatureWriter(object):
 
         return "[%s]" % " ".join(glyphs)
 
+    def _getClasses(self, separate=False):
+        """Return all kerning classes together."""
+
+        leftClasses = dict(self.leftFeaClasses)
+        leftClasses.update(self.leftUfoClasses)
+        rightClasses = dict(self.rightFeaClasses)
+        rightClasses.update(self.rightUfoClasses)
+        if separate:
+            return leftClasses, rightClasses
+
+        classes = leftClasses
+        classes.update(rightClasses)
+        return classes
+
     def _makeFeaClassName(self, name):
         """Make a glyph class name which is legal to use in feature text.
 
@@ -219,9 +230,7 @@ class KernFeatureWriter(object):
         """
 
         name = "@%s" % re.sub(r"[^A-Za-z0-9._]", r"", name)
-        existingClassNames = (
-            list(self.leftFeaClasses.keys()) + list(self.rightFeaClasses.keys()) +
-            list(self.groups.keys()))
+        existingClassNames = set(self_.getClasses().keys())
         i = 1
         origName = name
         while name in existingClassNames:

--- a/Lib/ufo2ft/kernFeatureWriter.py
+++ b/Lib/ufo2ft/kernFeatureWriter.py
@@ -305,7 +305,7 @@ class KernFeatureWriter(object):
         """
 
         name = "@%s" % re.sub(r"[^A-Za-z0-9._]", r"", name)
-        existingClassNames = set(self_.getClasses().keys())
+        existingClassNames = set(self._getClasses().keys())
         i = 1
         origName = name
         while name in existingClassNames:

--- a/Lib/ufo2ft/kernFeatureWriter.py
+++ b/Lib/ufo2ft/kernFeatureWriter.py
@@ -253,12 +253,18 @@ class KernFeatureWriter(object):
             (self.rightClassKerning, self.rtlRightClassKerning, (False, True)),
             (self.classPairKerning, self.rtlClassPairKerning, (True, True)))
 
-        for origKerning, rtlKerning, (leftIsClass, rightIsClass) in allKerning:
+        for origKerning, rtlKerning, classFlags in allKerning:
             for pair in list(origKerning.keys()):
-                lhs, rhs = pair
-                leftGlyphs = classes[lhs] if leftIsClass else [lhs]
-                rightGlyphs = classes[rhs] if rightIsClass else [rhs]
-                if any(self._glyphIsRtl(g) for g in leftGlyphs + rightGlyphs):
+                allGlyphs = []
+                for glyphs, isClass in zip(pair, classFlags):
+                    if not isClass:
+                        allGlyphs.append(glyphs)
+                    elif glyphs.startswith('@'):
+                        allGlyphs.extend(classes[glyphs])
+                    else:
+                        assert glyphs.startswith('[') and glyphs.endswith(']')
+                        allGlyphs.extend(glyphs[1:-1].split())
+                if any(self._glyphIsRtl(g) for g in allGlyphs):
                     rtlKerning[pair] = origKerning.pop(pair)
 
     def _addKerning(self, lines, kerning, rtl=False, enum=False,

--- a/Lib/ufo2ft/kernFeatureWriter.py
+++ b/Lib/ufo2ft/kernFeatureWriter.py
@@ -82,13 +82,14 @@ class KernFeatureWriter(object):
             self._splitRtlKerning()
 
         # write the lookups and feature
-        lines.append("lookup kern_ltr {")
-        self._addKerning(lines, self.glyphPairKerning)
-        self._addKerning(lines, self.leftClassKerning, enum=True)
-        self._addKerning(lines, self.rightClassKerning, enum=True)
-        self._addKerning(lines, self.classPairKerning)
-        lines.append("} kern_ltr;")
-        lines.append("")
+        if self.ltrScripts or not self.rtlScripts:
+            lines.append("lookup kern_ltr {")
+            self._addKerning(lines, self.glyphPairKerning)
+            self._addKerning(lines, self.leftClassKerning, enum=True)
+            self._addKerning(lines, self.rightClassKerning, enum=True)
+            self._addKerning(lines, self.classPairKerning)
+            lines.append("} kern_ltr;")
+            lines.append("")
 
         if self.rtlScripts:
             lines.append("lookup kern_rtl {")

--- a/Lib/ufo2ft/kernFeatureWriter.py
+++ b/Lib/ufo2ft/kernFeatureWriter.py
@@ -68,12 +68,9 @@ class KernFeatureWriter(object):
         # write the feature
         lines.append("feature kern {")
         self._addKerning(lines, self.glyphPairKerning)
-        if self.leftClassKerning:
-            self._addKerning(lines, self.leftClassKerning, enum=True)
-        if self.rightClassKerning:
-            self._addKerning(lines, self.rightClassKerning, enum=True)
-        if self.classPairKerning:
-            self._addKerning(lines, self.classPairKerning)
+        self._addKerning(lines, self.leftClassKerning, enum=True)
+        self._addKerning(lines, self.rightClassKerning, enum=True)
+        self._addKerning(lines, self.classPairKerning)
         lines.append("} kern;")
 
         return linesep.join(lines)

--- a/Lib/ufo2ft/kernFeatureWriter.py
+++ b/Lib/ufo2ft/kernFeatureWriter.py
@@ -2,7 +2,10 @@ from __future__ import print_function, division, absolute_import, unicode_litera
 from fontTools.misc.py23 import unichr
 
 import re
-import unicodedata
+try:
+    import unicodedata2 as unicodedata
+except ImportError:
+    import unicodedata
 
 
 class KernFeatureWriter(object):

--- a/Lib/ufo2ft/kernFeatureWriter.py
+++ b/Lib/ufo2ft/kernFeatureWriter.py
@@ -397,7 +397,8 @@ class KernFeatureWriter(object):
         uv = self.font[name].unicode
         while uv is None and any(d in name for d in delims):
             name = name[:max(name.rfind(d) for d in delims)]
-            uv = self.font[name].unicode
+            if name in self.font:
+                uv = self.font[name].unicode
         if uv is None:
             return False
         return unicodedata.bidirectional(unichr(uv)) in ('R', 'AL')


### PR DESCRIPTION
Goal is to close https://github.com/googlei18n/ufo2ft/issues/8
cc @behdad @graphicore

Not sure if this is exactly what we want. Especially https://github.com/googlei18n/ufo2ft/commit/7e9fdf8bc6b270b8427d78e8e26cf8e1c8c6a8c6, which simply moves rules from the LTR lookup to the RTL lookup when a glyph has bidi type "R" or "AL". Is that enough, or do we need to copy all rules, and only exclude the rules from RTL with glyphs having bidi type "L"?