### PR TITLE
outlineOTF: automatically set 'USE_MY_METRICS' flag for TrueType composite glyphs

### DIFF
--- a/Lib/ufo2ft/outlineOTF.py
+++ b/Lib/ufo2ft/outlineOTF.py
@@ -957,7 +957,8 @@ class OutlineTTFCompiler(OutlineCompiler):
     @staticmethod
     def autoUseMyMetrics(ttGlyph, width, glyphSet):
         """ Set the "USE_MY_METRICS" flag on the first component having the
-        same advance width as the composite glyph, no transform and no shift.
+        same advance width as the composite glyph, no transform and no
+        horizontal shift (but allow it to shift vertically).
         This forces the composite glyph to use the possibly hinted horizontal
         metrics of the sub-glyph, instead of those from the "hmtx" table.
         """
@@ -968,7 +969,7 @@ class OutlineTTFCompiler(OutlineCompiler):
                 # component uses '{first,second}Pt' instead of 'x' and 'y'
                 continue
             if (glyphSet[baseName].width == width and
-                    transform == (1, 0, 0, 1, 0, 0)):
+                    transform[:-1] == (1, 0, 0, 1, 0)):
                 component.flags |= USE_MY_METRICS
                 break
 

--- a/Lib/ufo2ft/outlineOTF.py
+++ b/Lib/ufo2ft/outlineOTF.py
@@ -13,6 +13,7 @@ from fontTools.pens.ttGlyphPen import TTGlyphPen
 from fontTools.ttLib.tables.O_S_2f_2 import Panose
 from fontTools.ttLib.tables._h_e_a_d import mac_epoch_diff
 from fontTools.ttLib.tables._n_a_m_e import NameRecord
+from fontTools.ttLib.tables._g_l_y_f import USE_MY_METRICS
 
 from ufo2ft.fontInfoData import getFontBounds, getAttrWithFallback, dateStringToTimeValue, dateStringForNow, intListToNum, normalizeStringForPostscript
 
@@ -943,10 +944,33 @@ class OutlineTTFCompiler(OutlineCompiler):
         glyf.glyphs = {}
         glyf.glyphOrder = self.glyphOrder
 
+        allGlyphs = self.allGlyphs
         for name in self.glyphOrder:
+            glyph = allGlyphs[name]
             pen = TTGlyphPen(allGlyphs)
-            allGlyphs[name].draw(pen)
-            glyf[name] = pen.glyph()
+            glyph.draw(pen)
+            ttGlyph = pen.glyph()
+            if ttGlyph.isComposite() and self.autoUseMyMetrics:
+                self.autoUseMyMetrics(ttGlyph, glyph.width, allGlyphs)
+            glyf[name] = ttGlyph
+
+    @staticmethod
+    def autoUseMyMetrics(ttGlyph, width, glyphSet):
+        """ Set the "USE_MY_METRICS" flag on the first component having the
+        same advance width as the composite glyph, no transform and no shift.
+        This forces the composite glyph to use the possibly hinted horizontal
+        metrics of the sub-glyph, instead of those from the "hmtx" table.
+        """
+        for component in ttGlyph.components:
+            try:
+                baseName, transform = component.getComponentInfo()
+            except AttributeError:
+                # component uses '{first,second}Pt' instead of 'x' and 'y'
+                continue
+            if (glyphSet[baseName].width == width and
+                    transform == (1, 0, 0, 1, 0, 0)):
+                component.flags |= USE_MY_METRICS
+                break
 
 
 class StubGlyph(object):


### PR DESCRIPTION
In TrueType glyf components, there's a bit flag named "USE_MY_METRICS" that, when set, forces the composite glyph to use the advance width and side bearings of the component's original glyph, instead of the ones from the "hmtx" table.

This is useful for accented glyphs, for example, when the metrics of the base glyph have been modified through delta instructions, and one wants the composite glyphs to inherit such metrics.

All the font editors I know set this flag automatically on generating TTFs, or at least they do that when the TTF is to be hinted.
 
Some, like FontLab, set it only on the first component in the list of components, and simply check if it has the same advance width as the composite as a whole.

Others, like Robofont, set it to any component that has the same width as the composite, but only if it has no scale, nor x or y shift.

In this PR I opted for a mix of the two: I set the flag on the one component that has same width as the composite (the first one that matches, which is not necessarily the first component), but only if it has no transform nor horizontal or vertical offsets. 

I would like to hear your feedback on whether this is a sensible default for ufo2ft's OutlineTTFCompiler.

Note: the static method `autoUseMyMetrics` can be easily disabled by setting it to None, or replaced with a different one with the same signature.