### PR TITLE
kernFeatureWriter: fix issue when collecting right kerning classes from UFO groups

### DIFF
--- a/Lib/ufo2ft/kernFeatureWriter.py
+++ b/Lib/ufo2ft/kernFeatureWriter.py
@@ -135,6 +135,7 @@ class KernFeatureWriter(object):
             if leftIsClass:
                 self.leftUfoClasses[left] = self.groups[left]
                 if rightIsClass:
+                    self.rightUfoClasses[right] = self.groups[right]
                     self.classPairKerning[glyphPair] = val
                 else:
                     self.leftClassKerning[glyphPair] = val


### PR DESCRIPTION
it was skipped when both 'leftIsClass' and 'rightIsClass' are true.