### PR TITLE
outlineOTF: do not allow negative advance widths when generating hmtx table

### DIFF
--- a/Lib/ufo2ft/outlineOTF.py
+++ b/Lib/ufo2ft/outlineOTF.py
@@ -539,6 +539,9 @@ class OutlineCompiler(object):
         hmtx.metrics = {}
         for glyphName, glyph in self.allGlyphs.items():
             width = glyph.width
+            if width < 0:
+                raise ValueError(
+                    "The width should not be negative: '%s'" % (glyphName))
             left = 0
             if len(glyph) or len(glyph.components):
                 # lsb should be consistent with glyf xMin, which is just


### PR DESCRIPTION
The hmtx specs clearly say `advanceWidth` field in `_longHorMetric` struct must be an `USHORT`.

FreeType also interprets the field as an unsigned short, leading to extremely wide rendering.

Acrobat Reader returns a "A number is out of range" error if a negative advance is found in a PDF, and then all the widths will show up scrambled.

The UFO spec is silent about it (just says 'integer or float'), however Glyphs.app prevents this issue by not allowing to set negative advance widths.

Hence we should do the same in ufo2ft.