### PR TITLE
Fix building TTF fonts from cubic outlines

### DIFF
--- a/Lib/ufo2ft/outlineOTF.py
+++ b/Lib/ufo2ft/outlineOTF.py
@@ -944,7 +944,6 @@ class OutlineTTFCompiler(OutlineCompiler):
         glyf.glyphs = {}
         glyf.glyphOrder = self.glyphOrder
 
-        allGlyphs = self.allGlyphs
         for name in self.glyphOrder:
             glyph = allGlyphs[name]
             pen = TTGlyphPen(allGlyphs)


### PR DESCRIPTION
Regression from 0f4bc039535fd61aae20aa2a42eeef5cf0ed9f16, looks like a
bad merge.