### PR TITLE
Travis, tox, pytest, etc.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+sudo: false
+language: python
+python:
+  - "2.7"
+  - "3.5"
+install: pip install tox-travis
+script: tox

--- a/Lib/ufo2ft/fontInfoData.py
+++ b/Lib/ufo2ft/fontInfoData.py
@@ -527,37 +527,37 @@ def _test():
     """
     >>> info = _TestInfoObject()
 
-    >>> getAttrWithFallback(info, "familyName")
-    'Family Name'
-    >>> getAttrWithFallback(info, "styleName")
-    'Style Name'
+    >>> print(getAttrWithFallback(info, "familyName"))
+    Family Name
+    >>> print(getAttrWithFallback(info, "styleName"))
+    Style Name
 
     >>> getAttrWithFallback(info, "styleMapFamilyName") == u'Family Name Style Name'
     True
     >>> info.styleMapFamilyName = "Style Map Family Name"
-    >>> getAttrWithFallback(info, "styleMapFamilyName")
-    'Style Map Family Name'
+    >>> print(getAttrWithFallback(info, "styleMapFamilyName"))
+    Style Map Family Name
 
-    >>> getAttrWithFallback(info, "openTypeNamePreferredFamilyName")
-    'Family Name'
-    >>> getAttrWithFallback(info, "openTypeNamePreferredSubfamilyName")
-    'Style Name'
-    >>> getAttrWithFallback(info, "openTypeNameCompatibleFullName")
-    'Style Map Family Name'
+    >>> print(getAttrWithFallback(info, "openTypeNamePreferredFamilyName"))
+    Family Name
+    >>> print(getAttrWithFallback(info, "openTypeNamePreferredSubfamilyName"))
+    Style Name
+    >>> print(getAttrWithFallback(info, "openTypeNameCompatibleFullName"))
+    Style Map Family Name
 
     >>> getAttrWithFallback(info, "openTypeHheaAscender")
     750
     >>> getAttrWithFallback(info, "openTypeHheaDescender")
     -250
 
-    >>> getAttrWithFallback(info, "openTypeNameVersion")
-    '0.000'
+    >>> print(getAttrWithFallback(info, "openTypeNameVersion"))
+    Version 0.000
     >>> info.versionMinor = 1
     >>> info.versionMajor = 1
-    >>> getAttrWithFallback(info, "openTypeNameVersion")
-    '1.001'
+    >>> print(getAttrWithFallback(info, "openTypeNameVersion"))
+    Version 1.001
 
-    >>> getAttrWithFallback(info, "openTypeNameUniqueID") == u'1.001;NONE;Style Map Family Name Regular'
+    >>> getAttrWithFallback(info, "openTypeNameUniqueID") == u'Version 1.001;NONE;Style Map Family Name Regular'
     True
 
     >>> getAttrWithFallback(info, "openTypeOS2TypoAscender")
@@ -571,8 +571,8 @@ def _test():
 
     >>> getAttrWithFallback(info, "postscriptSlantAngle")
     0
-    >>> getAttrWithFallback(info, "postscriptWeightName")
-    'Normal'
+    >>> print(getAttrWithFallback(info, "postscriptWeightName"))
+    Normal
     """
 
 if __name__ == "__main__":

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,25 @@
+[tox]
+envlist = py27, py35
+
+[testenv]
+deps =
+    pytest
+    -rrequirements.txt
+commands =
+    py.test {posargs}
+
+[pytest]
+minversion = 2.8
+testpaths =
+    Lib/ufo2ft
+python_files =
+    *_test.py
+python_classes =
+    *Test
+addopts =
+    # run py.test in verbose mode
+    -v
+    # show extra test summary info
+    -r a
+    # run doctests in all .py modules
+    --doctest-modules


### PR DESCRIPTION
I added a minimal `.travis.yml` and `tox.ini` to run py.test script on Python 2.7 and 3.5. This should be enough to get us started on writing the test suite.

I used this nice package that makes configuring Travis for tox much easier:
https://github.com/ryanhiebert/tox-travis