### PR TITLE
kernFeatureWriter: fix py3 issue with for-loop modifying dict it's looping through

### DIFF
--- a/Lib/ufo2ft/kernFeatureWriter.py
+++ b/Lib/ufo2ft/kernFeatureWriter.py
@@ -199,7 +199,7 @@ class KernFeatureWriter(object):
     def _correctUfoClassNames(self):
         """Detect and replace illegal class names found in UFO kerning."""
 
-        for oldName, members in self.groups.items():
+        for oldName, members in list(self.groups.items()):
             newName = self._makeFeaClassName(oldName)
             if oldName == newName:
                 continue


### PR DESCRIPTION
Python3 `dict.items` returns an iterator, so we need to copy the items to a list before we can modify them inside `_correctUfoClassNames` for-loop.

Otherwise, bad things happen.