### PR TITLE
Set name record from font.info

### DIFF
--- a/Lib/ufo2ft/fontInfoData.py
+++ b/Lib/ufo2ft/fontInfoData.py
@@ -169,7 +169,7 @@ def openTypeOS2WinDescentFallback(info):
 # postscript
 
 _postscriptFontNameExceptions = set("[](){}<>/%")
-_postscriptFontNameAllowed = set([unichr(i) for i in range(33, 137)])
+_postscriptFontNameAllowed = set([unichr(i) for i in range(33, 127)])
 
 def normalizeStringForPostscript(s, allowSpaces=True):
     s = tounicode(s)
@@ -180,7 +180,10 @@ def normalizeStringForPostscript(s, allowSpaces=True):
         if c in _postscriptFontNameExceptions:
             continue
         if c not in _postscriptFontNameAllowed:
+            # Use compatibility decomposed form, to keep parts in ascii
             c = unicodedata.normalize("NFKD", c)
+            if not set(c) < _postscriptFontNameAllowed:
+                c = tounicode(tobytes(c, errors="replace"))
         normalized.append(tostr(c))
     return "".join(normalized)
 

--- a/Lib/ufo2ft/fontInfoData.py
+++ b/Lib/ufo2ft/fontInfoData.py
@@ -289,6 +289,7 @@ staticFallbackData = dict(
     openTypeNameLicenseURL=None,
     openTypeNameDescription=None,
     openTypeNameSampleText=None,
+    openTypeNameRecords=[],
 
     openTypeOS2WidthClass=5,
     openTypeOS2WeightClass=400,


### PR DESCRIPTION
- Set name record from font.info, these have priority over the ones built from other info. If they are in the UFO we can assume they should be used directly.
- Add option to set legacy Mac names. Some legacy environments or odd applications need this.
- That option also adds legacy Mac cmap for the same reasons.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlei18n/ufo2ft/66)
<!-- Reviewable:end -->
