### PR TITLE
Python3: unorderable types: tuple() < str()

### DIFF
--- a/Lib/ufo2ft/markFeatureWriter.py
+++ b/Lib/ufo2ft/markFeatureWriter.py
@@ -86,9 +86,7 @@ class MarkFeatureWriter(object):
             anchorList.extend(self.mkmkAnchorList)
 
         added = set()
-        for _, accentAnchorName in sorted(anchorList):
-            if accentAnchorName in added:
-                continue
+        for accentAnchorName in sorted(set(n for _, n in anchorList)):
             added.add(accentAnchorName)
             self._addClass(lines, accentAnchorName)
 


### PR DESCRIPTION
ligaAnchorList has (tuple, str) while others have (str, str)