### PR TITLE
outtlineOTF.py: decode name table's strings to unicode(encoding='ascii')

### DIFF
--- a/Lib/ufo2ft/outlineOTF.py
+++ b/Lib/ufo2ft/outlineOTF.py
@@ -275,7 +275,12 @@ class OutlineCompiler(object):
             platformId = nameRecord["platformID"]
             platEncId = nameRecord["encodingID"]
             langId = nameRecord["languageID"]
-            nameVal = nameRecord["string"]
+            # on Python 2, plistLib (used by ufoLib) returns unicode strings
+            # only when plist data contain non-ascii characters, and returns
+            # ascii-encoded bytes when it can. On the other hand, fontTools's
+            # name table `setName` method wants unicode strings, so we must
+            # decode them first
+            nameVal = tounicode(nameRecord["string"], encoding='ascii')
             name.setName(nameVal, nameId, platformId, platEncId, langId)
 
         # Build name records
@@ -322,6 +327,7 @@ class OutlineCompiler(object):
             nameVal = nameVals[nameId]
             if not nameVal:
                 continue
+            nameVal = tounicode(nameVal, encoding='ascii')
             platformId = 3
             platEncId = 10 if _isNonBMP(nameVal) else 1
             langId = 0x409


### PR DESCRIPTION
This follows a change in fontTools, whereby the `NameRecord.setName` method no longer silently coerces bytes to unicode, but keeps the distinction clearer and accepts either one or the other.

See https://github.com/fonttools/fonttools/pull/688

Currently, on Python 2, ufo2ft was passing to fontTools `setName` method `bytes` strings instead of `unicode` strings. This is because `plistLib`, which is used by `ufoLib` to parse UFO plist files, returns ascii-encoded bytes whenever it can, and only returns unicode strings if it can't encode
plist strings to ascii (in a distinctively Python-2-esque fashion).

Confusing text with binary data is not cool, so we now make sure we decode the name strings using 'ascii' before calling `setName`.

If they are already unicode, they will be left untouched; if they are not, then it must be because Python2's plistLib has encoded them to 'ascii', so we decode them back as such.

(That's some of the things we need to do to maintain a single py23 code-base)