### PR TITLE
otfPostProcessor: don't rename glyphs if they are not in UFO lib.postscriptNames

### DIFF
--- a/Lib/ufo2ft/otfPostProcessor.py
+++ b/Lib/ufo2ft/otfPostProcessor.py
@@ -46,11 +46,10 @@ class OTFPostProcessor(object):
     def _build_production_name(self, glyph):
         """Build a production name for a single glyph."""
 
-        # use name from Glyphs source if available
+        # use PostScript names from UFO lib if available
         if self._postscriptNames:
             production_name = self._postscriptNames.get(glyph.name)
-            if production_name:
-                return production_name
+            return production_name if production_name else glyph.name
 
         # use name derived from unicode value
         unicode_val = glyph.unicode


### PR DESCRIPTION
http://unifiedfontobject.org/versions/ufo3/lib.plist/#publicpostscriptnames

> If a glyph’s name is not defined in this mapping, the glyph’s name should be used as the Postscript name.

instead ufo2ft is renaming those glyphs anyway to uniXXXX names, even if they are correct AGLFN names and hence their friendly and production names are the same (e.g. "A" --> "uni0065").