### PR TITLE
Skip zero-length classes in _removeConflictingKerningRules

### DIFF
--- a/Lib/ufo2ft/kernFeatureWriter.py
+++ b/Lib/ufo2ft/kernFeatureWriter.py
@@ -254,7 +254,8 @@ class KernFeatureWriter(object):
                     nlGlyphs.append(lGlyph)
                     seen[pair] = val
             if nlGlyphs != lGlyphs:
-                self.leftClassKerning[liststr(nlGlyphs), rGlyph] = val
+                if len(nlGlyphs) > 0: 
+                    self.leftClassKerning[liststr(nlGlyphs), rGlyph] = val
                 del self.leftClassKerning[lClass, rGlyph]
 
         # remove conflicts in left glyph / right class rules
@@ -267,7 +268,8 @@ class KernFeatureWriter(object):
                     nrGlyphs.append(rGlyph)
                     seen[pair] = val
             if nrGlyphs != rGlyphs:
-                self.rightClassKerning[lGlyph, liststr(nrGlyphs)] = val
+                if len(nrGlyphs) > 0: 
+                    self.rightClassKerning[lGlyph, liststr(nrGlyphs)] = val
                 del self.rightClassKerning[lGlyph, rClass]
 
     def _addGlyphClasses(self, lines):

--- a/Lib/ufo2ft/kernFeatureWriter.py
+++ b/Lib/ufo2ft/kernFeatureWriter.py
@@ -254,7 +254,7 @@ class KernFeatureWriter(object):
                     nlGlyphs.append(lGlyph)
                     seen[pair] = val
             if nlGlyphs != lGlyphs:
-                if len(nlGlyphs) > 0: 
+                if nlGlyphs: 
                     self.leftClassKerning[liststr(nlGlyphs), rGlyph] = val
                 del self.leftClassKerning[lClass, rGlyph]
 
@@ -268,7 +268,7 @@ class KernFeatureWriter(object):
                     nrGlyphs.append(rGlyph)
                     seen[pair] = val
             if nrGlyphs != rGlyphs:
-                if len(nrGlyphs) > 0: 
+                if nrGlyphs: 
                     self.rightClassKerning[lGlyph, liststr(nrGlyphs)] = val
                 del self.rightClassKerning[lGlyph, rClass]
 


### PR DESCRIPTION
After running _removeConflictingKerningRules we may get a zero-length
class. ufo2ft was emitting lines like "pos A [] 0;" which were causing
makeOTF to fail.