### PR TITLE
[kernFeatureWriter] keep kerning groups' internal order

### DIFF
--- a/Lib/ufo2ft/kernFeatureWriter.py
+++ b/Lib/ufo2ft/kernFeatureWriter.py
@@ -180,9 +180,9 @@ class KernFeatureWriter(object):
 
         groups = {}
         for name, members in self.groups.items():
-            newMembers = set(members).intersection(allGlyphs)
+            newMembers = [g for g in members if g in allGlyphs]
             if newMembers:
-                groups[name] = list(newMembers)
+                groups[name] = newMembers
 
         kerning = {}
         for glyphPair, val in sorted(self.kerning.items()):

--- a/tests/kernFeatureWriter_test.py
+++ b/tests/kernFeatureWriter_test.py
@@ -17,6 +17,27 @@ class KernFeatureWriterTest(unittest.TestCase):
         writer._collectFeaClasses()
         self.assertEquals(writer.leftFeaClasses, expected)
 
+    def test__cleanupMissingGlyphs(self):
+        groups = {
+            "public.kern1.A": ["A", "Aacute", "Abreve", "Acircumflex"],
+            "public.kern2.B": ["B", "D", "E", "F"],
+        }
+        ufo = Font()
+        for glyphs in groups.values():
+            for glyph in glyphs:
+                ufo.newGlyph(glyph)
+        ufo.groups.update(groups)
+        del ufo["Abreve"]
+        del ufo["D"]
+
+        writer = KernFeatureWriter(ufo)
+        self.assertEquals(writer.groups, groups)
+
+        writer._cleanupMissingGlyphs()
+        self.assertEquals(writer.groups, {
+            "public.kern1.A": ["A", "Aacute", "Acircumflex"],
+            "public.kern2.B": ["B", "E", "F"]})
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Some time ago I noticed that, when compiling the same source fonts with fontmake on Python 3 and comparing the output of the different runs, all the time I would get slightly different PairPos Format 2 GPOS subtables. In particular, the ClassDef indexes were different in a random way.

Initially we thought the origin of the issue was in fonttools.otlLib:
https://github.com/fonttools/fonttools/issues/766

However, this was only part of the problem, and we fixed that with 
https://github.com/fonttools/fonttools/commit/7d1ddb237ec2f4c6d4982ff076fd15c1d47771f2
and
https://github.com/anthrotype/fonttools/commit/3b3e74f90b06f497839abec6a4ab126346c39759

But even after that, for some fonts I was still getting different outputs at every run when running on Python 3.

I believe the cause of this is not just in the above mentioned fonttools issue, but also in ufo2ft kernFeatureWriter.

The latter in fact writes slightly different `features.fea` every time one runs it under Python 3...

A UFO group.plist is a dictionary of _lists_ of glyph names keyed by the group names. 
The problem occurs while the `_cleanupMissingGlyphs` method attempts to remove from the groups the glyphs that are missing in the font: to do that it uses sets intersection, and then convert the set back to a list.

But when converting a list to a set, the internal order of that list is lost. Converting it back to a list cannot restore the original order, but even worse it does not guarantee that the new order will be the same all the time (depending on implementation).

In Python 3, unsorted collections (like set or dict) are hashed using a random seed.
When converting a set into a list, the order of the resulting list is likely to be different upon every subsequent run.

With this patch, we still prune the missing glyphs but avoid using sets, so that all pythons always produce the same result given the same input, over and over.