### PR TITLE
Robustly detect which OpenType layout features are defined

### DIFF
--- a/tests/compiler_test.py
+++ b/tests/compiler_test.py
@@ -22,6 +22,7 @@ def loadUFO(filename):
 
 class CompilerTest(unittest.TestCase):
     _tempdir, _num_tempfiles = None, 0
+    _layoutTables = ["GDEF", "GSUB", "GPOS", "BASE"]
 
     def test_TestFont(self):
         # We have specific unit tests for CFF vs TrueType output, but we run
@@ -30,10 +31,19 @@ class CompilerTest(unittest.TestCase):
         self.expectTTX(compileTTF(loadUFO("TestFont.ufo")), "TestFont.ttx")
         self.expectTTX(compileOTF(loadUFO("TestFont.ufo")), "TestFont-CFF.ttx")
 
-    def test_regressions(self):
-        layout = ["GDEF", "GSUB", "GPOS", "BASE"]
+    def test_features(self):
+        """Checks how the compiler handles features.fea
+
+        The compiler should detect which features are defined by the
+        features.fea inside the compiled UFO, or by feature files that
+        are included from there.  The compiler should only inject
+        auto-generated features (kern, mark, mkmk) if the UFO does
+        not list them in features.fea.
+
+        https://github.com/googlei18n/ufo2ft/issues/108
+        """
         self.expectTTX(compileTTF(loadUFO("Bug108.ufo")), "Bug108.ttx",
-                       tables=layout)
+                       tables=self._layoutTables)
 
     def _temppath(self, suffix):
         if not self._tempdir:

--- a/tests/data/Bug108.ttx
+++ b/tests/data/Bug108.ttx
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="3.7">
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="kern"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="2"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <PairPos index="0" Format="1">
+          <Coverage Format="1">
+            <Glyph value="uni0061"/>
+          </Coverage>
+          <ValueFormat1 value="4"/>
+          <ValueFormat2 value="0"/>
+          <!-- PairSetCount=1 -->
+          <PairSet index="0">
+            <!-- PairValueCount=1 -->
+            <PairValueRecord index="0">
+              <SecondGlyph value="uni0062"/>
+              <Value1 XAdvance="-10"/>
+            </PairValueRecord>
+          </PairSet>
+        </PairPos>
+      </Lookup>
+    </LookupList>
+  </GPOS>
+
+</ttFont>

--- a/tests/data/Bug108.ufo/data/included.fea
+++ b/tests/data/Bug108.ufo/data/included.fea
@@ -1,0 +1,3 @@
+feature kern {
+  pos a b -10;
+} kern;

--- a/tests/data/Bug108.ufo/features.fea
+++ b/tests/data/Bug108.ufo/features.fea
@@ -1,0 +1,1 @@
+include(data/included.fea)

--- a/tests/data/Bug108.ufo/fontinfo.plist
+++ b/tests/data/Bug108.ufo/fontinfo.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>familyName</key>
+		<string>Bug 108</string>
+		<key>note</key>
+		<string>https://github.com/googlei18n/ufo2ft/issues/108</string>
+		<key>unitsPerEm</key>
+		<integer>1000</integer>
+		<key>xHeight</key>
+		<integer>500</integer>
+		<key>ascender</key>
+		<integer>750</integer>
+		<key>capHeight</key>
+		<integer>750</integer>
+		<key>descender</key>
+		<integer>-250</integer>
+		<key>postscriptUnderlinePosition</key>
+		<integer>-200</integer>
+		<key>postscriptUnderlineThickness</key>
+		<integer>20</integer>
+	</dict>
+</plist>

--- a/tests/data/Bug108.ufo/glyphs/_notdef.glif
+++ b/tests/data/Bug108.ufo/glyphs/_notdef.glif
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name=".notdef" format="2">
+	<advance width="500"/>
+	<outline>
+		<contour>
+			<point x="450" y="0" type="line"/>
+			<point x="450" y="750" type="line"/>
+			<point x="50" y="750" type="line"/>
+			<point x="50" y="0" type="line"/>
+		</contour>
+		<contour>
+			<point x="400" y="50" type="line"/>
+			<point x="100" y="50" type="line"/>
+			<point x="100" y="700" type="line"/>
+			<point x="400" y="700" type="line"/>
+		</contour>
+	</outline>
+</glyph>

--- a/tests/data/Bug108.ufo/glyphs/a.glif
+++ b/tests/data/Bug108.ufo/glyphs/a.glif
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="a" format="2">
+	<unicode hex="0061"/>
+	<advance width="388"/>
+	<outline>
+		<contour>
+			<point x="66" y="0" type="line"/>
+			<point x="194" y="510" type="line"/>
+			<point x="322" y="0" type="line"/>
+		</contour>
+	</outline>
+</glyph>

--- a/tests/data/Bug108.ufo/glyphs/b.glif
+++ b/tests/data/Bug108.ufo/glyphs/b.glif
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="b" format="2">
+	<unicode hex="0062"/>
+	<advance width="410"/>
+	<outline>
+		<contour>
+			<point x="100" y="505" type="line"/>
+			<point x="310" y="505" type="line"/>
+			<point x="310" y="-5" type="line"/>
+			<point x="100" y="-5" type="line"/>
+		</contour>
+	</outline>
+</glyph>

--- a/tests/data/Bug108.ufo/glyphs/c.glif
+++ b/tests/data/Bug108.ufo/glyphs/c.glif
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="c" format="2">
+	<unicode hex="0063"/>
+	<advance width="374"/>
+	<outline>
+		<contour>
+			<point x="300" y="-10" type="line"/>
+			<point x="150" y="-10"/>
+			<point x="100" y="40"/>
+			<point x="100" y="245" type="curve"/>
+			<point x="100" y="450"/>
+			<point x="150" y="500"/>
+			<point x="300" y="500" type="curve"/>
+		</contour>
+	</outline>
+</glyph>

--- a/tests/data/Bug108.ufo/glyphs/contents.plist
+++ b/tests/data/Bug108.ufo/glyphs/contents.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>.notdef</key>
+		<string>_notdef.glif</string>
+		<key>a</key>
+		<string>a.glif</string>
+		<key>b</key>
+		<string>b.glif</string>
+		<key>c</key>
+		<string>c.glif</string>
+		<key>space</key>
+		<string>space.glif</string>
+	</dict>
+</plist>

--- a/tests/data/Bug108.ufo/glyphs/space.glif
+++ b/tests/data/Bug108.ufo/glyphs/space.glif
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="space" format="2">
+	<unicode hex="0020"/>
+	<advance width="250"/>
+</glyph>

--- a/tests/data/Bug108.ufo/groups.plist
+++ b/tests/data/Bug108.ufo/groups.plist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+	</dict>
+</plist>

--- a/tests/data/Bug108.ufo/kerning.plist
+++ b/tests/data/Bug108.ufo/kerning.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>a</key>
+		<dict>
+			<key>a</key>
+			<integer>-666</integer>
+			<key>b</key>
+			<integer>-666</integer>
+		</dict>
+		<key>b</key>
+		<dict>
+			<key>a</key>
+			<integer>-666</integer>
+		</dict>
+	</dict>
+</plist>

--- a/tests/data/Bug108.ufo/layercontents.plist
+++ b/tests/data/Bug108.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<array>
+		<array>
+			<string>public.default</string>
+			<string>glyphs</string>
+		</array>
+	</array>
+</plist>

--- a/tests/data/Bug108.ufo/lib.plist
+++ b/tests/data/Bug108.ufo/lib.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>public.glyphOrder</key>
+		<array>
+			<string>.notdef</string>
+			<string>space</string>
+			<string>a</string>
+			<string>b</string>
+			<string>c</string>
+		</array>
+	</dict>
+</plist>

--- a/tests/data/Bug108.ufo/metainfo.plist
+++ b/tests/data/Bug108.ufo/metainfo.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>formatVersion</key>
+		<integer>3</integer>
+	</dict>
+</plist>


### PR DESCRIPTION
This removes the capability to override features in the feature file
with auto-generated content, since I did't see any reasonable way for
keeping this functionality while also making the detection of declared
features more robust. If somebody wants to use the auto-generated
features instead of those in the input UFO, they can trivially delete
the `mark`, `mkmk` and `kern` features from their UFO's feature files.

Arguably, removing the capability for overriding features.fea can be
considered an improvement because this makes the build process more
"hermetic", meaning the compilation results is now less dependent on
things that are defined outside the UFO file being compiled.

Resolves https://github.com/googlei18n/ufo2ft/issues/108.