### PR TITLE
[outlineOTF] only write PostScript BlueValues when are not empty

### DIFF
--- a/Lib/ufo2ft/outlineOTF.py
+++ b/Lib/ufo2ft/outlineOTF.py
@@ -883,15 +883,19 @@ class OutlineOTFCompiler(OutlineCompiler):
         if isinstance(stemSnapV, list):
             stemSnapV = [round(i) for i in stemSnapV]
         # only write the blues data if some blues are defined.
-        if (blueValues or otherBlues):
+        if any((blueValues, otherBlues, familyBlues, familyOtherBlues)):
             private.rawDict["BlueFuzz"] = blueFuzz
             private.rawDict["BlueShift"] = blueShift
             private.rawDict["BlueScale"] = blueScale
             private.rawDict["ForceBold"] = forceBold
-            private.rawDict["BlueValues"] = blueValues
-            private.rawDict["OtherBlues"] = otherBlues
-            private.rawDict["FamilyBlues"] = familyBlues
-            private.rawDict["FamilyOtherBlues"] = familyOtherBlues
+            if blueValues:
+                private.rawDict["BlueValues"] = blueValues
+            if otherBlues:
+                private.rawDict["OtherBlues"] = otherBlues
+            if familyBlues:
+                private.rawDict["FamilyBlues"] = familyBlues
+            if familyOtherBlues:
+                private.rawDict["FamilyOtherBlues"] = familyOtherBlues
         # only write the stems if both are defined.
         if (stemSnapH and stemSnapV):
             private.rawDict["StemSnapH"] = stemSnapH


### PR DESCRIPTION
Currently ufo2ft writes all the _four_ blue values (`BlueValues`, `OtherBlues`, `FamilyBlues`, `FamilyOtherBlues`) whenever either `postscriptBlueValues` or `postscriptOtherBlues` are non-empty lists in the UFO fontinfo.plist. It only checks those two, but then writes all four of them.

So even if the others are empty, they will still be compiled as empty deltas in the CFF PrivateDict.

Now, it turns out the OpenType Sanitizer will reject such CFF fonts with empty Blues operators in the PrivateDict:

See https://github.com/khaledhosny/ots/blob/dcfa05f/src/cff.cc#L378-L385

I am not sure whether it's OTS that is being too picky, or whether these empty deltas in PrivateDict are actually invalid in CFF.

In any case, we can work around this OTS failure by setting each of these PrivateDict blues only if they are not empty -- rather than checking if only two of them are non-empty.

The same ufo2ft behaviour of writing empty deltas was also triggering another fonttools issue (now fixed):
fonttools/fonttools#883