### PR TITLE
support roundTolerance and float coords in CFF; fix bbox calculation

### DIFF
--- a/Lib/ufo2ft/__init__.py
+++ b/Lib/ufo2ft/__init__.py
@@ -13,13 +13,22 @@ __version__ = "0.4.0.dev0"
 def compileOTF(ufo, outlineCompilerClass=OutlineOTFCompiler,
                featuresCompilerClass=FeaturesCompiler, mtiFeaFiles=None,
                kernWriterClass=KernFeatureWriter, markWriterClass=MarkFeatureWriter,
-               glyphOrder=None, useProductionNames=True, optimizeCFF=True):
+               glyphOrder=None, useProductionNames=True, optimizeCFF=True,
+               roundTolerance=None):
     """Create FontTools CFF font from a UFO.
 
     *optimizeCFF* sets whether the CFF table should be subroutinized.
+
+    *roundTolerance* (float) controls the rounding of point coordinates.
+      It is defined as the maximum absolute difference between the original
+      float and the rounded integer value.
+      By default, all floats are rounded to integer (tolerance 0.5); a value
+      of 0 completely disables rounding; values in between only round floats
+      which are close to their integral part within the tolerated range.
     """
 
-    outlineCompiler = outlineCompilerClass(ufo, glyphOrder)
+    outlineCompiler = outlineCompilerClass(
+        ufo, glyphOrder, roundTolerance=roundTolerance)
     otf = outlineCompiler.compile()
 
     featuresCompiler = featuresCompilerClass(

--- a/Lib/ufo2ft/fontInfoData.py
+++ b/Lib/ufo2ft/fontInfoData.py
@@ -17,7 +17,6 @@ import logging
 import time
 import unicodedata
 
-from fontTools.misc.arrayTools import unionRect, intRect
 from fontTools.misc.py23 import tobytes, tostr, tounicode, unichr, round2
 from fontTools.misc.textTools import binary2num
 import ufoLib

--- a/Lib/ufo2ft/fontInfoData.py
+++ b/Lib/ufo2ft/fontInfoData.py
@@ -17,7 +17,7 @@ import logging
 import time
 import unicodedata
 
-from fontTools.misc.arrayTools import unionRect
+from fontTools.misc.arrayTools import unionRect, intRect
 from fontTools.misc.py23 import tobytes, tostr, tounicode, unichr, round2
 from fontTools.misc.textTools import binary2num
 import ufoLib
@@ -461,33 +461,6 @@ def preflightInfo(info):
         if not hasattr(info, attr) or getattr(info, attr) is None:
             missingRecommended.add(attr)
     return dict(missingRequired=missingRequired, missingRecommended=missingRecommended)
-
-def getFontBounds(font):
-    """
-    Get a tuple of (xMin, yMin, xMax, yMax) for all
-    glyphs in the given *font*.
-    """
-    rect = None
-    # defcon
-    if hasattr(font, "bounds"):
-        rect = font.bounds
-    # others
-    else:
-        for glyph in font:
-            # robofab
-            if hasattr(glyph,"box"):
-                bounds = glyph.box
-            # others
-            else:
-                bounds = glyph.bounds
-            if rect is None:
-                rect = bounds
-                continue
-            if rect is not None and bounds is not None:
-                rect = unionRect(rect, bounds)
-    if rect is None:
-        rect = (0, 0, 0, 0)
-    return rect
 
 # -----------------
 # Low Level Support

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 fonttools==3.9.0
 ufoLib==2.0.0
-defcon==0.2.3
+defcon==0.2.4
 cu2qu==1.1.1
 compreffor==0.4.4

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     install_requires=[
         "fonttools>=3.9",
         "ufoLib>=2.0.0",
-        "defcon>=0.2.3",
+        "defcon>=0.2.4",
         "cu2qu>=1.1.1",
         "compreffor>=0.4.4",
     ],

--- a/tests/data/TestFont-CFF.ttx
+++ b/tests/data/TestFont-CFF.ttx
@@ -37,8 +37,8 @@
     <descent value="-250"/>
     <lineGap value="200"/>
     <advanceWidthMax value="500"/>
-    <minLeftSideBearing value="0"/>
-    <minRightSideBearing value="0"/>
+    <minLeftSideBearing value="50"/>
+    <minRightSideBearing value="50"/>
     <xMaxExtent value="450"/>
     <caretSlopeRise value="1"/>
     <caretSlopeRun value="0"/>


### PR DESCRIPTION
The `compileOTF` function and the `OutlineOTFCompiler` class now take a `roundTolerance` float argument that is passed on to the fontTools `T2CharStringPen` and affects how float coordinates are rounded to integers.
The default value (0.5) means round all coordinates to integers, 0 means no rounding, whereas numbers in between result in some rounding and not others.

The font and glyphs bounding box calculation has been refactored to account for the new CFF roundTolerance parameter, and also to fix issue #26, whereby the use of `math.floor()` instead of `round()` when computing the TrueType glyphs' bounds could lead to the `hmtx` table's left sidebearings be out-of-sync with the `glyf` table's `xMin` values.

The `hhea` and `vhea` are now computed directly from the values in `hmtx` and `vmtx` tables, rather than independently from them. The control point bounding box is used instead of the defcon glyph's `{left,right,top,bottom}Margin` attributes, as the latter are based on the actual glyph bounds, whereas in the `{h,v}mtx` we use the control point bounds.

Fixes issues #24 and #106.