### PR TITLE
Fix encoding

### DIFF
--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -101,7 +101,7 @@ class BaseOutlineCompiler(object):
         """
         Make bounding boxes for all the glyphs, and return a dictionary of
         BoundingBox(xMin, xMax, yMin, yMax) namedtuples keyed by glyph names.
-        The bounding boxA of empty glyphs (without contours or components) is
+        The bounding box of empty glyphs (without contours or components) is
         set to None.
 
         Float values are rounded to integers using the built-in round().
@@ -770,11 +770,11 @@ class OutlineOTFCompiler(BaseOutlineCompiler):
         """
         Make bounding boxes for all the glyphs, and return a dictionary of
         BoundingBox(xMin, xMax, yMin, yMax) namedtuples keyed by glyph names.
-        The bounding boxA of empty glyphs (without contours or components) is
+        The bounding box of empty glyphs (without contours or components) is
         set to None.
 
         Check that the float values are within the range of the specified
-        self.roundTolerance, and if so useA the rounded value; else take the
+        self.roundTolerance, and if so use the rounded value; else take the
         floor or ceiling to ensure that the bounding box encloses the original
         values.
         """

--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -101,7 +101,7 @@ class BaseOutlineCompiler(object):
         """
         Make bounding boxes for all the glyphs, and return a dictionary of
         BoundingBox(xMin, xMax, yMin, yMax) namedtuples keyed by glyph names.
-        The bounding box of empty glyphs (without contours or components) is
+        The bounding boxA of empty glyphs (without contours or components) is
         set to None.
 
         Float values are rounded to integers using the built-in round().
@@ -770,11 +770,11 @@ class OutlineOTFCompiler(BaseOutlineCompiler):
         """
         Make bounding boxes for all the glyphs, and return a dictionary of
         BoundingBox(xMin, xMax, yMin, yMax) namedtuples keyed by glyph names.
-        The bounding box of empty glyphs (without contours or components) is
+        The bounding boxA of empty glyphs (without contours or components) is
         set to None.
 
         Check that the float values are within the range of the specified
-        self.roundTolerance, and if so use the rounded value; else take the
+        self.roundTolerance, and if so useA the rounded value; else take the
         floor or ceiling to ensure that the bounding box encloses the original
         values.
         """


### PR DESCRIPTION
The outlineCompiler module is encoded in latin1 with some special characters in docstrings. Since it does not specify encoding, it cannot be loaded and tests fail for python 2. CI was not able to detect the issue because tox environment seems to set encoding to something more permissive like UTF-8.

This could be solved in a single commit, but some change would be required (like adding encoding to the top of the file or changing a comment). This seems to be the cleanest way to solve this issue.