### PR TITLE
[setup.py] add 'bump_version' and 'release' setuptools sub-commands

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,132 @@
 
 from __future__ import print_function, division, absolute_import
 import sys
-from setuptools import setup, find_packages
+from setuptools import setup, find_packages, Command
+from distutils import log
+
+
+class bump_version(Command):
+
+    description = "increment the package version and commit the changes"
+
+    user_options = [
+        ("major", None, "bump the first digit, for incompatible API changes"),
+        ("minor", None, "bump the second digit, for new backward-compatible features"),
+        ("patch", None, "bump the third digit, for bug fixes (default)"),
+    ]
+
+    def initialize_options(self):
+        self.minor = False
+        self.major = False
+        self.patch = False
+
+    def finalize_options(self):
+        part = None
+        for attr in ("major", "minor", "patch"):
+            if getattr(self, attr, False):
+                if part is None:
+                    part = attr
+                else:
+                    from distutils.errors import DistutilsOptionError
+                    raise DistutilsOptionError(
+                        "version part options are mutually exclusive")
+        self.part = part or "patch"
+
+    def bumpversion(self, part, tag=False, message=None):
+        """ Run bumpversion.main() with the specified arguments, and return the
+        new computed version string.
+        """
+        import bumpversion
+
+        args = (
+            (['--verbose'] if self.verbose > 1 else []) +
+            (['--tag'] if tag else ['--no-tag']) +
+            (['--message', message] if message is not None else []) +
+            [part]
+        )
+        log.debug(
+            "$ bumpversion %s" % " ".join(a.replace(" ", "\\ ") for a in args))
+
+        bumpversion.main(args)
+
+    def run(self):
+        log.info("bumping '%s' version" % self.part)
+        self.bumpversion(self.part)
+
+
+class release(bump_version):
+    """Drop the developmental release '.devN' suffix from the package version,
+    open the default text $EDITOR to write release notes, commit the changes
+    and generate a git tag.
+
+    Release notes can also be set with the -m/--message option, or by reading
+    from standard input.
+    """
+
+    description = "tag a new release"
+
+    user_options = [
+        ("message=", 'm', "message containing the release notes"),
+    ]
+
+    def initialize_options(self):
+        self.message = None
+
+    def finalize_options(self):
+        import re
+
+        current_version = self.distribution.metadata.get_version()
+        if not re.search(r"\.dev[0-9]+", current_version):
+            from distutils.errors import DistutilsSetupError
+            raise DistutilsSetupError(
+                "current version (%s) has no '.devN' suffix.\n       "
+                "Run 'setup.py bump_version', or use any of "
+                "--major, --minor, --patch options" % current_version)
+
+        message = self.message
+        if message is None:
+            if sys.stdin.isatty():
+                # stdin is interactive, use editor to write release notes
+                message = self.edit_release_notes()
+            else:
+                # read release notes from stdin pipe
+                message = sys.stdin.read()
+
+        if not message.strip():
+            from distutils.errors import DistutilsSetupError
+            raise DistutilsSetupError("release notes message is empty")
+
+        self.message = "Release {new_version}\n\n%s" % (message)
+
+    @staticmethod
+    def edit_release_notes():
+        """Use the default text $EDITOR to write release notes.
+        If $EDITOR is not set, use 'nano'."""
+        from tempfile import mkstemp
+        import os
+        import shlex
+        import subprocess
+
+        text_editor = shlex.split(os.environ.get('EDITOR', 'nano'))
+
+        fd, tmp = mkstemp(prefix='bumpversion-')
+        try:
+            os.close(fd)
+            with open(tmp, 'w') as f:
+                f.write("\n\n# Write release notes.\n"
+                        "# Lines starting with '#' will be ignored.")
+            subprocess.check_call(text_editor + [tmp])
+            with open(tmp, 'r') as f:
+                changes = "".join(
+                    l for l in f.readlines() if not l.startswith('#'))
+        finally:
+            os.remove(tmp)
+        return changes
+
+    def run(self):
+        log.info("stripping developmental release suffix")
+        # drop '.dev0' suffix, commit with given message and create git tag
+        self.bumpversion("release", tag=True,  message=self.message)
 
 
 needs_pytest = {'pytest', 'test'}.intersection(sys.argv)
@@ -27,7 +152,8 @@ setup(
     packages=find_packages("Lib"),
     include_package_data=True,
     license="MIT",
-    setup_requires=pytest_runner + wheel,
+    setup_requires=pytest_runner + wheel + (
+        ['bumpversion'] if {'release', 'bump_version'}.intersection(sys.argv) else []),
     tests_require=[
         'pytest>=2.8',
     ],
@@ -38,6 +164,10 @@ setup(
         "cu2qu>=1.1.1",
         "compreffor>=0.4.4",
     ],
+    cmdclass={
+        "release": release,
+        "bump_version": bump_version,
+    },
     classifiers=[
         'Development Status :: 4 - Beta',
         "Environment :: Console",


### PR DESCRIPTION
@brawer asked me how I go about tagging new releases. The process involves running the [bumpversion](https://github.com/peritus/bumpversion) script, which reads its configuration from the `setup.cfg` file.

```sh
$ bumpversion [patch|minor|major|release]
```

However I also like to embed the release notes in the body of the commit/tag message. In order to do that, I use a shell script that fires my favourite text editor with a temporary file, and then passes the output automatically to the bumpversion script as the commit/tag message.

This shell script of mine is too hackish to share.. So I ended up rewriting it in python as a custom setuptools command. The advantage of this one is that it does not require you to install bumpversion, as it uses setuptools to bootstrap it as a `setup_requires`.

Here how this works:

To bump the third, last digit, for bug fixes:
```
$ python setup.py bump_version --patch
```

(the --patch option is default so you can omit)

To bump the second digit, for new backward-compatible features:
```
$ python setup.py bump_version --minor
```

To bump the first digit, for incompatible API changes:
```
$ python setup.py bump_version --major
```

Finally, to drop the pre-release suffix (`.dev0`) and cut a new, final release:
```
$ python setup.py release -m "My release notes"
```

If the `--message/-m` option is omitted, the command will automatically open your shell's default "$EDITOR" (I've set mine to `subl -n -w` in by `.bashrc`) and then the output will be passed on to bumpversion as the commit and tag messages.

Once the tag is created, you can `git push --follow-tags` and wait for the bots to complete their packaging tasks.

After you verify that the distribution packages have been uploaded successfully to PyPI, it is important that you run once again:

```
$ python setup.py bump_version
$ git push
```

so that the patch digit is bumped and the `.dev0` suffix is appended, which signal the opening of a new development cycle.

***

We shall do the same for the whole fontmake stack, so other devs can tag new releases whenever they need to, without my assistance.

Sascha, please let me know if something is not clear.