### PR TITLE
change default unique id fallback and full name

### DIFF
--- a/Lib/ufo2ft/fontInfoData.py
+++ b/Lib/ufo2ft/fontInfoData.py
@@ -84,13 +84,12 @@ def openTypeNameVersionFallback(info):
 
 def openTypeNameUniqueIDFallback(info):
     """
-    Fallback to *openTypeNameVersion;openTypeOS2VendorID;styleMapFamilyName styleMapStyleName*.
+    Fallback to *openTypeNameVersion;openTypeOS2VendorID;postscriptFontName*.
     """
-    version = getAttrWithFallback(info, "openTypeNameVersion")
+    version = getAttrWithFallback(info, "openTypeNameVersion").replace("Version ", "")
     vendor = getAttrWithFallback(info, "openTypeOS2VendorID")
-    familyName = getAttrWithFallback(info, "styleMapFamilyName")
-    styleName = getAttrWithFallback(info, "styleMapStyleName").title()
-    return "%s;%s;%s %s" % (version, vendor, familyName, styleName)
+    fontName = getAttrWithFallback(info, "postscriptFontName")
+    return "%s;%s;%s" % (version, vendor, fontName)
 
 def openTypeNamePreferredFamilyNameFallback(info):
     """

--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -302,11 +302,17 @@ class BaseOutlineCompiler(object):
         # Build name records
         familyName = getAttrWithFallback(font.info, "styleMapFamilyName")
         styleName = getAttrWithFallback(font.info, "styleMapStyleName").title()
+        preferredFamilyName = getAttrWithFallback(
+            font.info, "openTypeNamePreferredFamilyName")
+        preferredSubfamilyName = getAttrWithFallback(
+            font.info, "openTypeNamePreferredSubfamilyName")
 
-        # If name ID 2 is "Regular", it can be omitted from name ID 4
-        fullName = familyName
-        if styleName != "Regular":
-            fullName += " %s" % styleName
+        # The full name (id 4) is a combination of preferred family and
+        # subfamily names. If the latter is "Regular", it can be omitted.
+        # NOTE Glyphs.app always keeps "Regular" in the full name...
+        fullName = preferredFamilyName
+        if preferredSubfamilyName != "Regular":
+            fullName += " %s" % preferredSubfamilyName
 
         nameVals = {
             0: getAttrWithFallback(font.info, "copyright"),
@@ -324,10 +330,8 @@ class BaseOutlineCompiler(object):
             12: getAttrWithFallback(font.info, "openTypeNameDesignerURL"),
             13: getAttrWithFallback(font.info, "openTypeNameLicense"),
             14: getAttrWithFallback(font.info, "openTypeNameLicenseURL"),
-            16: getAttrWithFallback(
-                font.info, "openTypeNamePreferredFamilyName"),
-            17: getAttrWithFallback(
-                font.info, "openTypeNamePreferredSubfamilyName"),
+            16: preferredFamilyName,
+            17: preferredSubfamilyName,
         }
 
         # don't add typographic names if they are the same as the legacy ones

--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -306,13 +306,7 @@ class BaseOutlineCompiler(object):
             font.info, "openTypeNamePreferredFamilyName")
         preferredSubfamilyName = getAttrWithFallback(
             font.info, "openTypeNamePreferredSubfamilyName")
-
-        # The full name (id 4) is a combination of preferred family and
-        # subfamily names. If the latter is "Regular", it can be omitted.
-        # NOTE Glyphs.app always keeps "Regular" in the full name...
-        fullName = preferredFamilyName
-        if preferredSubfamilyName != "Regular":
-            fullName += " %s" % preferredSubfamilyName
+        fullName = "%s %s" % (preferredFamilyName, preferredSubfamilyName)
 
         nameVals = {
             0: getAttrWithFallback(font.info, "copyright"),

--- a/tests/data/TestFont-CFF.ttx
+++ b/tests/data/TestFont-CFF.ttx
@@ -127,7 +127,7 @@
       OpenType name Table Unique ID
     </namerecord>
     <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
-      Some Font Regular (Style Map Family Name)
+      Some Font (Preferred Family Name) Regular (Preferred Subfamily Name)
     </namerecord>
     <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
       OpenType name Table Version

--- a/tests/data/TestFont.ttx
+++ b/tests/data/TestFont.ttx
@@ -249,7 +249,7 @@
       OpenType name Table Unique ID
     </namerecord>
     <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
-      Some Font Regular (Style Map Family Name)
+      Some Font (Preferred Family Name) Regular (Preferred Subfamily Name)
     </namerecord>
     <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
       OpenType name Table Version

--- a/tests/fontInfoData_test.py
+++ b/tests/fontInfoData_test.py
@@ -45,7 +45,7 @@ class GetAttrWithFallbackTest(unittest.TestCase):
 
         self.assertEqual(
             getAttrWithFallback(info, "openTypeNameUniqueID"),
-            "Version 1.001;NONE;Family Name Style Name Regular")
+            "1.001;NONE;FamilyName-StyleName")
 
         self.assertEqual(getAttrWithFallback(info, "postscriptSlantAngle"), 0)
         self.assertEqual(


### PR DESCRIPTION
1) for the unique id (nameid=3), the patch would change the fallback (used when `openTypeNameUniqueID` is not set in fontinfo.plist) from:

```
Version 1.901;GOOG;Noto Sans Tamil ExtraBold
```

to 

```
1.901;GOOG;NotoSansTamil-ExtraBold
```

Note how the latter string is more compact but still contains all the "unique" information of the former. That's how makeotf and Glyphs.app do also.


2) The full name was composed of styleMapFamilyName + styleMapStyleName; however, I think it makes more sense for it to be the combination of the _preferred_ family and subfamily (which fall back to the UFO's `familyName` and `styleName`).

The opentype spec allows both:

> The full font name is generally a combination of name IDs 1 and 2, or of name IDs 16 and 17, or a similar human-readable variant.

I tend to prefer the "preferred" ones, as the styleMap* names can sometimes be shortened to fit the legacy max-32 char limitations, while the full name should have more room to accommodate the *full*
names...

E.g., if one sets the `styleMapFamilyName` to say `Noto Sans Tamil ExtBd`, the full name would still be `Noto Sans Tamil ExtraBold`, instead of `Noto Sans Tamil ExtBd`.

***

There is still the open question as to whether to keep or leave the "Regular" in the full name.
I'm currently swinging towards keeping it, like Glyphs.app currently does... Though I haven't committed the latter change yet.

See also https://github.com/googlei18n/fontmake/issues/209#issuecomment-321239770