### PR TITLE
FastUFO: UFO3

### DIFF
--- a/Lib/ufo2ft/fastUFO.py
+++ b/Lib/ufo2ft/fastUFO.py
@@ -193,32 +193,33 @@ class Glyph(object):
 class Info(object):
     def __init__(self):
         attrs = (
-            'familyName styleName '
-            'note openTypeGaspRangeRecords openTypeHeadFlags '
-            'openTypeNameDescription openTypeNameLicense '
-            'openTypeNameLicenseURL openTypeNameRecords '
-            'openTypeNameSampleText '
-            'openTypeNameUniqueID openTypeNameVersion '
-            'openTypeNameWWSFamilyName openTypeNameWWSSubfamilyName '
-            'openTypeOS2CodePageRanges openTypeOS2FamilyClass '
-            'openTypeOS2Panose openTypeOS2Type openTypeOS2UnicodeRanges '
-            'openTypeOS2Selection openTypeHheaAscender openTypeHheaDescender '
-            'openTypeHheaLineGap openTypeOS2TypoAscender '
-            'openTypeOS2TypoDescender openTypeOS2TypoLineGap '
-            'openTypeOS2WinAscent openTypeOS2WinDescent '
-            'openTypeOS2WidthClass openTypeHeadCreated '
-            'openTypeOS2VendorID postscriptDefaultCharacter '
-            'postscriptForceBold postscriptIsFixedPitch '
-            'postscriptWindowsCharacterSet trademark unitsPerEm '
-            'postscriptUnderlineThickness postscriptUnderlinePosition '
-            'openTypeOS2WidthClass openTypeOS2WeightClass'
-        ).split()
+            'familyName', 'styleName', 'note', 'openTypeGaspRangeRecords',
+            'openTypeHeadFlags', 'openTypeNameDescription',
+            'openTypeNameLicense', 'openTypeNameLicenseURL',
+            'openTypeNameRecords', 'openTypeNameSampleText',
+            'openTypeNameUniqueID', 'openTypeNameVersion',
+            'openTypeNameWWSFamilyName', 'openTypeNameWWSSubfamilyName',
+            'openTypeOS2CodePageRanges', 'openTypeOS2FamilyClass',
+            'openTypeOS2Panose', 'openTypeOS2Type', 'openTypeOS2UnicodeRanges',
+            'openTypeOS2Selection', 'openTypeHheaAscender',
+            'openTypeHheaDescender', 'openTypeHheaLineGap',
+            'openTypeOS2TypoAscender', 'openTypeOS2TypoDescender',
+            'openTypeOS2TypoLineGap', 'openTypeOS2WinAscent',
+            'openTypeOS2WinDescent', 'openTypeOS2WidthClass',
+            'openTypeHeadCreated', 'openTypeOS2VendorID',
+            'postscriptDefaultCharacter', 'postscriptForceBold',
+            'postscriptIsFixedPitch', 'postscriptWindowsCharacterSet',
+            'trademark', 'unitsPerEm', 'postscriptUnderlineThickness',
+            'postscriptUnderlinePosition', 'openTypeOS2WidthClass',
+            'openTypeOS2WeightClass'
+        )
         for attr in attrs:
             setattr(self, attr, None)
         array_attrs = (
-            'guidelines postscriptFamilyBlues postscriptFamilyOtherBlues '
-            'postscriptStemSnapH postscriptStemSnapV'
-        ).split()
+            'guidelines', 'postscriptFamilyBlues',
+            'postscriptFamilyOtherBlues', 'postscriptStemSnapH',
+            'postscriptStemSnapV'
+        )
         for attr in array_attrs:
             setattr(self, attr, [])
 

--- a/Lib/ufo2ft/fastUFO.py
+++ b/Lib/ufo2ft/fastUFO.py
@@ -299,6 +299,14 @@ class Font(object):
             return
         self.lib['public.glyphOrder'] = value
 
+    @property
+    def guidelines(self):
+        return self.info.guidelines
+
+    @guidelines.setter
+    def guidelines(self, guides):
+        self.info.guidelines = guides
+
     def save(self, path=None, formatVersion=3):
         if path is not None:
             self.path = path

--- a/Lib/ufo2ft/fastUFO.py
+++ b/Lib/ufo2ft/fastUFO.py
@@ -264,6 +264,9 @@ class Font(object):
         for name in self.keys():
             yield self.layers[self._defaultLayerName][name]
 
+    def __delitem__(self, name):
+        del self.layers[self._defaultLayerName][name]
+
     def keys(self):
         return self.layers[self._defaultLayerName].keys()
 
@@ -311,6 +314,9 @@ class Layer(object):
     def __iter__(self):
         for name in self.keys():
             yield self.glyphs[name]
+
+    def __delitem__(self, name):
+        del self.glyphs[name]
 
     def keys(self):
         return self.glyphs.keys()

--- a/Lib/ufo2ft/fastUFO.py
+++ b/Lib/ufo2ft/fastUFO.py
@@ -194,7 +194,8 @@ class Info(object):
         attrs = (
             'guidelines note openTypeGaspRangeRecords openTypeHeadFlags '
             'openTypeNameDescription openTypeNameLicense '
-            'openTypeNameLicenseURL openTypeNameRecords openTypeNameSampleText '
+            'openTypeNameLicenseURL openTypeNameRecords '
+            'openTypeNameSampleText '
             'openTypeNameUniqueID openTypeNameVersion '
             'openTypeNameWWSFamilyName openTypeNameWWSSubfamilyName '
             'openTypeOS2CodePageRanges openTypeOS2FamilyClass '

--- a/Lib/ufo2ft/fastUFO.py
+++ b/Lib/ufo2ft/fastUFO.py
@@ -272,6 +272,9 @@ class Font(object):
     def keys(self):
         return self.layers[self._defaultLayerName].keys()
 
+    def __len__(self):
+        return len(self.keys())
+
     def newGlyph(self, name):
         layer = self.layers[self._defaultLayerName]
         glyph = layer.newGlyph(name)

--- a/Lib/ufo2ft/fastUFO.py
+++ b/Lib/ufo2ft/fastUFO.py
@@ -205,6 +205,7 @@ class Info(object):
             'openTypeHheaLineGap openTypeOS2TypoAscender '
             'openTypeOS2TypoDescender openTypeOS2TypoLineGap '
             'openTypeOS2WinAscent openTypeOS2WinDescent '
+            'openTypeOS2WidthClass openTypeHeadCreated '
             'openTypeOS2VendorID postscriptDefaultCharacter '
             'postscriptForceBold postscriptIsFixedPitch '
             'postscriptWindowsCharacterSet trademark unitsPerEm '

--- a/Lib/ufo2ft/fastUFO.py
+++ b/Lib/ufo2ft/fastUFO.py
@@ -192,6 +192,7 @@ class Glyph(object):
 class Info(object):
     def __init__(self):
         attrs = (
+            'familyName styleName '
             'guidelines note openTypeGaspRangeRecords openTypeHeadFlags '
             'openTypeNameDescription openTypeNameLicense '
             'openTypeNameLicenseURL openTypeNameRecords '

--- a/Lib/ufo2ft/fastUFO.py
+++ b/Lib/ufo2ft/fastUFO.py
@@ -194,7 +194,7 @@ class Info(object):
     def __init__(self):
         attrs = (
             'familyName styleName '
-            'guidelines note openTypeGaspRangeRecords openTypeHeadFlags '
+            'note openTypeGaspRangeRecords openTypeHeadFlags '
             'openTypeNameDescription openTypeNameLicense '
             'openTypeNameLicenseURL openTypeNameRecords '
             'openTypeNameSampleText '
@@ -211,11 +211,16 @@ class Info(object):
             'postscriptForceBold postscriptIsFixedPitch '
             'postscriptWindowsCharacterSet trademark unitsPerEm '
             'postscriptUnderlineThickness postscriptUnderlinePosition '
-            'postscriptFamilyBlues postscriptFamilyOtherBlues'
             'openTypeOS2WidthClass openTypeOS2WeightClass'
         ).split()
         for attr in attrs:
             setattr(self, attr, None)
+        array_attrs = (
+            'guidelines postscriptFamilyBlues postscriptFamilyOtherBlues '
+            'postscriptStemSnapH postscriptStemSnapV'
+        ).split()
+        for attr in array_attrs:
+            setattr(self, attr, [])
 
 
 class Font(object):

--- a/Lib/ufo2ft/fastUFO.py
+++ b/Lib/ufo2ft/fastUFO.py
@@ -281,6 +281,18 @@ class Font(object):
         self.layers[name] = layer
         return layer
 
+    @property
+    def glyphOrder(self):
+        return self.lib.get('public.glyphOrder', [])
+
+    @glyphOrder.setter
+    def glyphOrder(self, value):
+        if value is None or len(value) == 0:
+            if 'public.glyphOrder' in self.lib:
+                del self.lib['public.glyphOrder']
+            return
+        self.lib['public.glyphOrder'] = value
+
     def save(self, path=None, formatVersion=3):
         if path is not None:
             self.path = path

--- a/tests/data/TestFont.ufo/glyphs/a.glif
+++ b/tests/data/TestFont.ufo/glyphs/a.glif
@@ -3,10 +3,10 @@
 	<unicode hex="0061"/>
 	<advance width="388"/>
 	<outline>
-		<contour>
-			<point x="66" y="0" type="line"/>
-			<point x="194" y="510" type="line"/>
-			<point x="322" y="0" type="line"/>
+		<contour identifier="T8s8JabQwz">
+			<point x="66" y="0" type="line" identifier="umpOAKb0oN"/>
+			<point x="194" y="510" type="line" identifier="qnhTEcN6fg"/>
+			<point x="322" y="0" type="line" identifier="RTPDhya9iK"/>
 		</contour>
 	</outline>
 </glyph>


### PR DESCRIPTION
This makes FastUFO support UFO3 instead of UFO2. Still work in progress: missing images support and unit tests.
It does speed up glyphsLib (glyphs2ufo is about twice as fast with fastUFO).