### PR TITLE
Sort kern groups members

### DIFF
--- a/Lib/ufo2ft/kernFeatureWriter.py
+++ b/Lib/ufo2ft/kernFeatureWriter.py
@@ -187,7 +187,7 @@ class KernFeatureWriter(object):
         for name, members in self.groups.items():
             newMembers = [g for g in members if g in allGlyphs]
             if newMembers:
-                groups[name] = newMembers
+                groups[name] = sorted(newMembers)
 
         kerning = {}
         for glyphPair, val in sorted(self.kerning.items()):

--- a/tests/kernFeatureWriter_test.py
+++ b/tests/kernFeatureWriter_test.py
@@ -19,8 +19,8 @@ class KernFeatureWriterTest(unittest.TestCase):
 
     def test__cleanupMissingGlyphs(self):
         groups = {
-            "public.kern1.A": ["A", "Aacute", "Abreve", "Acircumflex"],
-            "public.kern2.B": ["B", "D", "E", "F"],
+            "public.kern1.A": ["A", "Abreve", "Acircumflex", "Aacute"],
+            "public.kern2.B": ["B", "D", "F", "E"],
         }
         ufo = Font()
         for glyphs in groups.values():


### PR DESCRIPTION
Without this change (at least in Python 3) I get different order each time the font is built, it seems either defcon or ufoLib don’t give deterministic order.