### PR TITLE
Revert modified time changes

### DIFF
--- a/Lib/ufo2ft/__init__.py
+++ b/Lib/ufo2ft/__init__.py
@@ -19,7 +19,7 @@ def compileOTF(ufo, outlineCompilerClass=OutlineOTFCompiler,
                featureCompilerClass=FeatureCompiler, mtiFeaFiles=None,
                kernWriterClass=KernFeatureWriter, markWriterClass=MarkFeatureWriter,
                glyphOrder=None, useProductionNames=True, optimizeCFF=True,
-               roundTolerance=None, modifiedTime=None):
+               roundTolerance=None):
     """Create FontTools CFF font from a UFO.
 
     *optimizeCFF* sets whether the CFF table should be subroutinized.
@@ -30,14 +30,10 @@ def compileOTF(ufo, outlineCompilerClass=OutlineOTFCompiler,
       By default, all floats are rounded to integer (tolerance 0.5); a value
       of 0 completely disables rounding; values in between only round floats
       which are close to their integral part within the tolerated range.
-
-    *modifiedTime* sets the font modification time, in the format
-      YYYY/MM/DD HH:MM:SS. By default the current time will be used.
     """
 
     outlineCompiler = outlineCompilerClass(
-        ufo, glyphOrder, roundTolerance=roundTolerance,
-        modifiedTime=modifiedTime)
+        ufo, glyphOrder, roundTolerance=roundTolerance)
     otf = outlineCompiler.compile()
 
     featureCompiler = featureCompilerClass(
@@ -55,15 +51,14 @@ def compileTTF(ufo, outlineCompilerClass=OutlineTTFCompiler,
                featureCompilerClass=FeatureCompiler, mtiFeaFiles=None,
                kernWriterClass=KernFeatureWriter, markWriterClass=MarkFeatureWriter,
                glyphOrder=None, useProductionNames=True,
-               convertCubics=True, cubicConversionError=None, modifiedTime=None):
+               convertCubics=True, cubicConversionError=None):
     """Create FontTools TrueType font from a UFO.
 
     *convertCubics* and *cubicConversionError* specify how the conversion from cubic
     to quadratic curves should be handled.
     """
     outlineCompiler = outlineCompilerClass(
-        ufo, glyphOrder, convertCubics, cubicConversionError,
-        modifiedTime=modifiedTime)
+        ufo, glyphOrder, convertCubics, cubicConversionError)
     otf = outlineCompiler.compile()
 
     featureCompiler = featureCompilerClass(

--- a/Lib/ufo2ft/postProcessor.py
+++ b/Lib/ufo2ft/postProcessor.py
@@ -14,7 +14,7 @@ class PostProcessor(object):
         stream = BytesIO()
         otf.save(stream)
         stream.seek(0)
-        self.otf = TTFont(stream, recalcTimestamp=False)
+        self.otf = TTFont(stream)
         self._postscriptNames = ufo.lib.get('public.postscriptNames')
 
     def process(self, useProductionNames=True, optimizeCFF=True):

--- a/README.rst
+++ b/README.rst
@@ -116,12 +116,3 @@ Merging TTX
 If the UFO data directory has a ``com.github.fonttools.ttx`` folder with TTX
 files ending with ``.ttx``, these will be merged in the generated font.
 The index TTX (generated when using using ``ttx -s``) is not required.
-
-Font modification date
-~~~~~~~~~~~~~~~~~~~~~~
-
-By default ufo2ft will set the ``modified`` field in the ``head`` table to the
-current time. This can be overridden by setting the ``modifiedTime`` argument
-to ``compileOTF``/``compileTTF`` functions, or setting the environment
-variable ``SOURCE_DATE_EPOCH``. The argument takes priority over the
-environment variable.

--- a/tests/outlineCompiler_test.py
+++ b/tests/outlineCompiler_test.py
@@ -1,9 +1,7 @@
 from fontTools.ttLib import TTFont
 from fontTools.misc.py23 import basestring
 from defcon import Font
-from ufo2ft.fontInfoData import dateStringToTimeValue
 from ufo2ft.outlineCompiler import OutlineTTFCompiler, OutlineOTFCompiler
-from fontTools.ttLib.tables._h_e_a_d import mac_epoch_diff
 from fontTools.ttLib.tables._g_l_y_f import USE_MY_METRICS
 from ufo2ft import compileTTF
 import unittest
@@ -324,24 +322,6 @@ class TestNames(unittest.TestCase):
         result = compileTTF(self.ufo, useProductionNames=True)
         self.assertEqual(result.getGlyphOrder(),
                          ['.notdef', 'foo', 'bar', 'baz', 'meh', 'doh'])
-
-
-class TestModifiedTime(unittest.TestCase):
-
-    def setUp(self):
-        self.ufo = getTestUFO()
-
-    def test_modified_time_arg(self):
-        time = "2017/10/1 18:50:27"
-        compiler = OutlineTTFCompiler(self.ufo, modifiedTime=time)
-        compiler.compile()
-        self.assertEqual(compiler.otf["head"].modified + mac_epoch_diff, dateStringToTimeValue(time))
-
-    def test_source_date_epoch(self):
-        os.environ["SOURCE_DATE_EPOCH"] = "150687315"
-        compiler = OutlineTTFCompiler(self.ufo)
-        compiler.compile()
-        self.assertEqual(compiler.otf["head"].modified + mac_epoch_diff, 150687315)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is now handled by FontTools itself.

This reverts commits:
 bacea4743bd9221743c04fd631d6bfee0e745e1d
 8bc1625fa81ec2a20e5358db8e98abcb54aa9e14
 ed9b7ce8c719fc18e0bfbfcd781d772208520c98
 25676332e0c59b51a5e2e3f7582205e4ae2316fc
 09a7222ffc3a1af5d101977c1439d44c765aa2e1