### PR TITLE
Support remove overlaps and custom filters

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,5 @@
+comment: false
+coverage:
+    status:
+        project: off
+        patch: off

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,5 @@
 comment: false
 coverage:
     status:
-        project: off
-        patch: off
+        project: false
+        patch: false

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,34 @@
+[run]
+# measure 'branch' coverage in addition to 'statement' coverage
+# See: http://coverage.readthedocs.org/en/coverage-4.0.3/branch.html#branch
+branch = True
+
+# list of directories or packages to measure
+source = ufo2ft
+
+# these are treated as equivalent when combining data
+[paths]
+source =
+    Lib/ufo2ft
+    .tox/*/lib/python*/site-packages/ufo2ft
+    .tox/pypy*/site-packages/ufo2ft
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # keywords to use in inline comments to skip coverage
+    pragma: no cover
+
+    # don't complain if tests don't hit defensive assertion code
+    raise AssertionError
+    raise NotImplementedError
+
+    # don't complain if non-runnable code isn't run
+    if 0:
+    if __name__ == .__main__.:
+
+# ignore source code that can’t be found
+ignore_errors = True
+
+# when running a summary report, show missing lines
+show_missing = True

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ branches:
 install: pip install tox
 script: tox
 
+after_success:
+  - tox -e codecov
+
 deploy:
   # deploy to PyPI on tags
   - provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,17 @@
 sudo: false
 language: python
-python:
-  - "2.7"
-  - "3.6"
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=py27-cov
+    - python: 3.6
+      env: TOXENV=py36-cov
 branches:
   only:
     - master
     - /^v\d+\.\d+.*$/
 
-install: pip install tox-travis
+install: pip install tox
 script: tox
 
 deploy:

--- a/Lib/ufo2ft/__init__.py
+++ b/Lib/ufo2ft/__init__.py
@@ -55,7 +55,7 @@ def compileTTF(ufo, outlineCompilerClass=OutlineTTFCompiler,
                kernWriterClass=KernFeatureWriter, markWriterClass=MarkFeatureWriter,
                glyphOrder=None, useProductionNames=True,
                convertCubics=True, cubicConversionError=None,
-               removeOverlaps=False):
+               reverseDirection=True, removeOverlaps=False):
     """Create FontTools TrueType font from a UFO.
 
     *removeOverlaps* performs a union operation on all the glyphs' contours.
@@ -66,6 +66,7 @@ def compileTTF(ufo, outlineCompilerClass=OutlineTTFCompiler,
     outlineCompiler = outlineCompilerClass(
         ufo, glyphOrder, convertCubics=convertCubics,
         cubicConversionError=cubicConversionError,
+        reverseDirection=reverseDirection,
         removeOverlaps=removeOverlaps)
     otf = outlineCompiler.compile()
 

--- a/Lib/ufo2ft/__init__.py
+++ b/Lib/ufo2ft/__init__.py
@@ -18,7 +18,8 @@ def compileOTF(ufo, preProcessorClass=OTFPreProcessor,
                featureCompilerClass=FeatureCompiler,
                kernWriterClass=KernFeatureWriter, markWriterClass=MarkFeatureWriter,
                glyphOrder=None, useProductionNames=True, optimizeCFF=True,
-               roundTolerance=None, removeOverlaps=False):
+               roundTolerance=None, removeOverlaps=False,
+               inplace=False):
     """Create FontTools CFF font from a UFO.
 
     *removeOverlaps* performs a union operation on all the glyphs' contours.
@@ -32,7 +33,8 @@ def compileOTF(ufo, preProcessorClass=OTFPreProcessor,
       of 0 completely disables rounding; values in between only round floats
       which are close to their integral part within the tolerated range.
     """
-    preProcessor = preProcessorClass(ufo, removeOverlaps=removeOverlaps)
+    preProcessor = preProcessorClass(
+        ufo, inplace=inplace, removeOverlaps=removeOverlaps)
     glyphSet = preProcessor.process()
 
     outlineCompiler = outlineCompilerClass(
@@ -57,7 +59,8 @@ def compileTTF(ufo, preProcessorClass=TTFPreProcessor,
                kernWriterClass=KernFeatureWriter, markWriterClass=MarkFeatureWriter,
                glyphOrder=None, useProductionNames=True,
                convertCubics=True, cubicConversionError=None,
-               reverseDirection=True, removeOverlaps=False):
+               reverseDirection=True, removeOverlaps=False,
+               inplace=False):
     """Create FontTools TrueType font from a UFO.
 
     *removeOverlaps* performs a union operation on all the glyphs' contours.
@@ -66,7 +69,8 @@ def compileTTF(ufo, preProcessorClass=TTFPreProcessor,
     to quadratic curves should be handled.
     """
     preProcessor = preProcessorClass(
-        ufo, removeOverlaps=removeOverlaps,
+        ufo, inplace=inplace,
+        removeOverlaps=removeOverlaps,
         convertCubics=convertCubics,
         conversionError=cubicConversionError,
         reverseDirection=reverseDirection)

--- a/Lib/ufo2ft/__init__.py
+++ b/Lib/ufo2ft/__init__.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division, absolute_import
 
 from fontTools.misc.py23 import *
 
+from ufo2ft.preProcessor import OTFPreProcessor, TTFPreProcessor
 from ufo2ft.featureCompiler import FeatureCompiler
 from ufo2ft.kernFeatureWriter import KernFeatureWriter
 from ufo2ft.markFeatureWriter import MarkFeatureWriter
@@ -12,7 +13,8 @@ from ufo2ft.postProcessor import PostProcessor
 __version__ = "0.6.2"
 
 
-def compileOTF(ufo, outlineCompilerClass=OutlineOTFCompiler,
+def compileOTF(ufo, preProcessorClass=OTFPreProcessor,
+               outlineCompilerClass=OutlineOTFCompiler,
                featureCompilerClass=FeatureCompiler,
                kernWriterClass=KernFeatureWriter, markWriterClass=MarkFeatureWriter,
                glyphOrder=None, useProductionNames=True, optimizeCFF=True,
@@ -30,10 +32,12 @@ def compileOTF(ufo, outlineCompilerClass=OutlineOTFCompiler,
       of 0 completely disables rounding; values in between only round floats
       which are close to their integral part within the tolerated range.
     """
+    preProcessor = preProcessorClass(ufo, removeOverlaps=removeOverlaps)
+    glyphSet = preProcessor.process()
 
     outlineCompiler = outlineCompilerClass(
-        ufo, glyphOrder, roundTolerance=roundTolerance,
-        removeOverlaps=removeOverlaps)
+        ufo, glyphSet=glyphSet, glyphOrder=glyphOrder,
+        roundTolerance=roundTolerance)
     otf = outlineCompiler.compile()
 
     featureCompiler = featureCompilerClass(
@@ -47,7 +51,8 @@ def compileOTF(ufo, outlineCompilerClass=OutlineOTFCompiler,
     return otf
 
 
-def compileTTF(ufo, outlineCompilerClass=OutlineTTFCompiler,
+def compileTTF(ufo, preProcessorClass=TTFPreProcessor,
+               outlineCompilerClass=OutlineTTFCompiler,
                featureCompilerClass=FeatureCompiler,
                kernWriterClass=KernFeatureWriter, markWriterClass=MarkFeatureWriter,
                glyphOrder=None, useProductionNames=True,
@@ -60,11 +65,15 @@ def compileTTF(ufo, outlineCompilerClass=OutlineTTFCompiler,
     *convertCubics* and *cubicConversionError* specify how the conversion from cubic
     to quadratic curves should be handled.
     """
+    preProcessor = preProcessorClass(
+        ufo, removeOverlaps=removeOverlaps,
+        convertCubics=convertCubics,
+        conversionError=cubicConversionError,
+        reverseDirection=reverseDirection)
+    glyphSet = preProcessor.process()
+
     outlineCompiler = outlineCompilerClass(
-        ufo, glyphOrder, convertCubics=convertCubics,
-        cubicConversionError=cubicConversionError,
-        reverseDirection=reverseDirection,
-        removeOverlaps=removeOverlaps)
+        ufo, glyphSet=glyphSet, glyphOrder=glyphOrder)
     otf = outlineCompiler.compile()
 
     featureCompiler = featureCompilerClass(

--- a/Lib/ufo2ft/__init__.py
+++ b/Lib/ufo2ft/__init__.py
@@ -19,8 +19,10 @@ def compileOTF(ufo, outlineCompilerClass=OutlineOTFCompiler,
                featureCompilerClass=FeatureCompiler,
                kernWriterClass=KernFeatureWriter, markWriterClass=MarkFeatureWriter,
                glyphOrder=None, useProductionNames=True, optimizeCFF=True,
-               roundTolerance=None):
+               roundTolerance=None, removeOverlaps=False):
     """Create FontTools CFF font from a UFO.
+
+    *removeOverlaps* performs a union operation on all the glyphs' contours.
 
     *optimizeCFF* sets whether the CFF table should be subroutinized.
 
@@ -33,7 +35,8 @@ def compileOTF(ufo, outlineCompilerClass=OutlineOTFCompiler,
     """
 
     outlineCompiler = outlineCompilerClass(
-        ufo, glyphOrder, roundTolerance=roundTolerance)
+        ufo, glyphOrder, roundTolerance=roundTolerance,
+        removeOverlaps=removeOverlaps)
     otf = outlineCompiler.compile()
 
     featureCompiler = featureCompilerClass(
@@ -51,14 +54,19 @@ def compileTTF(ufo, outlineCompilerClass=OutlineTTFCompiler,
                featureCompilerClass=FeatureCompiler,
                kernWriterClass=KernFeatureWriter, markWriterClass=MarkFeatureWriter,
                glyphOrder=None, useProductionNames=True,
-               convertCubics=True, cubicConversionError=None):
+               convertCubics=True, cubicConversionError=None,
+               removeOverlaps=False):
     """Create FontTools TrueType font from a UFO.
+
+    *removeOverlaps* performs a union operation on all the glyphs' contours.
 
     *convertCubics* and *cubicConversionError* specify how the conversion from cubic
     to quadratic curves should be handled.
     """
     outlineCompiler = outlineCompilerClass(
-        ufo, glyphOrder, convertCubics, cubicConversionError)
+        ufo, glyphOrder, convertCubics=convertCubics,
+        cubicConversionError=cubicConversionError,
+        removeOverlaps=removeOverlaps)
     otf = outlineCompiler.compile()
 
     featureCompiler = featureCompilerClass(

--- a/Lib/ufo2ft/__init__.py
+++ b/Lib/ufo2ft/__init__.py
@@ -10,7 +10,7 @@ from ufo2ft.outlineCompiler import OutlineOTFCompiler, OutlineTTFCompiler
 from ufo2ft.postProcessor import PostProcessor
 
 
-__version__ = "0.6.2"
+__version__ = "1.0.0.dev0"
 
 
 def compileOTF(ufo, preProcessorClass=OTFPreProcessor,

--- a/Lib/ufo2ft/__init__.py
+++ b/Lib/ufo2ft/__init__.py
@@ -1,7 +1,5 @@
 from __future__ import print_function, division, absolute_import
 
-import logging
-
 from fontTools.misc.py23 import *
 
 from ufo2ft.featureCompiler import FeatureCompiler
@@ -12,7 +10,6 @@ from ufo2ft.postProcessor import PostProcessor
 
 
 __version__ = "0.6.2"
-log = logging.getLogger(__name__)
 
 
 def compileOTF(ufo, outlineCompilerClass=OutlineOTFCompiler,

--- a/Lib/ufo2ft/filters/__init__.py
+++ b/Lib/ufo2ft/filters/__init__.py
@@ -136,7 +136,7 @@ class BaseFilter(object):
         Subclasses must override this method, and return True
         when the glyph was modified.
         """
-        return False
+        raise NotImplementedError
 
     def __call__(self, glyphSet):
         """ Run this filter on all the included glyphs.

--- a/Lib/ufo2ft/filters/__init__.py
+++ b/Lib/ufo2ft/filters/__init__.py
@@ -1,0 +1,152 @@
+from __future__ import (
+    print_function, division, absolute_import, unicode_literals)
+
+import importlib
+import logging
+
+
+UFO2FT_FILTERS_KEY = "com.github.googlei18n.ufo2ft.filters"
+
+logger = logging.getLogger(__name__)
+
+
+def getFilterClass(filterName, pkg="ufo2ft.filters"):
+    """Given a filter name, import and return the filter class.
+    By default, filter modules are searched within the ``ufo2ft.filters``
+    package.
+    """
+    # TODO add support for third-party plugin discovery?
+    # if filter name is 'Foo Bar', the module should be called 'fooBar'
+    filterName = filterName.replace(" ", "")
+    moduleName = filterName[0].lower() + filterName[1:]
+    module = importlib.import_module(".".join([pkg, moduleName]))
+    # if filter name is 'Foo Bar', the class should be called 'FooBarFilter'
+    className = filterName[0].upper() + filterName[1:] + "Filter"
+    return getattr(module, className)
+
+
+def loadFilters(ufo):
+    """Parse custom filters from the ufo's lib.plist. Return two lists,
+    one for the filters that are applied before decomposition of composite
+    glyphs, another for the filters that are applied after decomposition.
+    """
+    preFilters, postFilters = [], []
+    for filterDict in ufo.lib.get(UFO2FT_FILTERS_KEY, []):
+        try:
+            filterClass = getFilterClass(filterDict["name"])
+        except (ImportError, AttributeError):
+            from pprint import pformat
+            logger.exception("Failed to load filter: %s", pformat(filterDict))
+            continue
+        filterObj = filterClass(include=filterDict.get("include"),
+                                exclude=filterDict.get("exclude"),
+                                *filterDict.get("args", []),
+                                **filterDict.get("kwargs", {}))
+        if filterDict.get("pre"):
+            preFilters.append(filterObj)
+        else:
+            postFilters.append(filterObj)
+    return preFilters, postFilters
+
+
+class BaseFilter(object):
+
+    # tuple of strings listing the names of required positional arguments
+    # which will be set as attributes of the filter instance
+    _args = ()
+
+    # dictionary containing the names of optional keyword arguments and
+    # their default values, which will be set as instance attributes
+    _kwargs = {}
+
+    def __init__(self, *args, **kwargs):
+        # process positional arguments
+        num_required = len(self._args)
+        num_args = len(args)
+        if num_args < num_required:
+            missing = [repr(a) for a in self._args[num_args:]]
+            num_missing = len(missing)
+            raise TypeError(
+                "missing {0} required positional argument{1}: {2}".format(
+                    num_missing,
+                    "s" if num_missing > 1 else "",
+                    ", ".join(missing)))
+        elif num_args > num_required:
+            extra = [repr(a) for a in args[num_required:]]
+            num_extra = len(extra)
+            raise TypeError(
+                "got {0} unsupported positional argument{1}: {2}".format(
+                    num_extra,
+                    "s" if num_extra > 1 else "",
+                    ", ".join(extra)))
+        for option, value in zip(self._args, args):
+            setattr(self, option, value)
+
+        # process optional keyword arguments
+        for option, default in self._kwargs.items():
+            setattr(self, option, kwargs.pop(option, default))
+
+        # process special include/exclude arguments
+        include = kwargs.pop('include', None)
+        exclude = kwargs.pop('exclude', None)
+        if include is not None and exclude is not None:
+            raise ValueError(
+                "'include' and 'exclude' arguments are mutually exclusive")
+        if callable(include):
+            # 'include' can be a function (e.g. lambda) that takes a
+            # glyph object and returns True/False based on some test
+            self.include = include
+        elif include is not None:
+            # or it can be a list of glyph names to be included
+            included = set(include)
+            self.include = lambda g: g.name in included
+        elif exclude is not None:
+            # alternatively one can provide a list of names to not include
+            excluded = set(exclude)
+            self.include = lambda g: g.name not in excluded
+        else:
+            # by default, all glyphs are included
+            self.include = lambda g: True
+
+        # raise if any unsupported keyword arguments
+        if kwargs:
+            num_left = len(kwargs)
+            raise TypeError(
+                "got {0}unsupported keyword argument{1}: {2}".format(
+                    "an " if num_left == 1 else "",
+                    "s" if len(kwargs) > 1 else "",
+                    ", ".join("'{}'".format(k) for k in kwargs)))
+
+        # run the filter's custom initialization code
+        self.start()
+
+    def __repr__(self):
+        items = ("{0}={1!r}".format(k, v)
+                 for k, v in sorted(self.__dict__.items())
+                 if v is not None and not k.startswith("_"))
+        return "{0}({1})".format(type(self).__name__, ", ".join(items))
+
+    def start(self):
+        """ Subclasses can perform here custom initialization code.
+        """
+        pass
+
+    def filter(self, glyph, glyphSet=None):
+        """ This is where the filter is applied to a single glyph.
+        Subclasses must override this method, and return True
+        when the glyph was modified.
+        """
+        return False
+
+    def __call__(self, glyphSet):
+        """ Run this filter on all the included glyphs.
+        Return the set of glyphs that were modified, if any.
+        """
+        filter_ = self.filter
+        include = self.include
+        modified = set()
+        for glyphName in glyphSet.keys():
+            glyph = glyphSet[glyphName]
+            if include(glyph) and filter_(glyph, glyphSet):
+                modified.add(glyphName)
+        return modified

--- a/Lib/ufo2ft/filters/__init__.py
+++ b/Lib/ufo2ft/filters/__init__.py
@@ -3,6 +3,7 @@ from __future__ import (
 
 import importlib
 import logging
+from fontTools.misc.loggingTools import Timer
 
 
 UFO2FT_FILTERS_KEY = "com.github.googlei18n.ufo2ft.filters"
@@ -138,6 +139,10 @@ class BaseFilter(object):
         """
         raise NotImplementedError
 
+    @property
+    def name(self):
+        return self.__class__.__name__
+
     def __call__(self, glyphSet):
         """ Run this filter on all the included glyphs.
         Return the set of glyphs that were modified, if any.
@@ -145,8 +150,13 @@ class BaseFilter(object):
         filter_ = self.filter
         include = self.include
         modified = set()
-        for glyphName in glyphSet.keys():
-            glyph = glyphSet[glyphName]
-            if include(glyph) and filter_(glyph, glyphSet):
-                modified.add(glyphName)
+
+        with Timer() as t:
+            for glyphName in glyphSet.keys():
+                glyph = glyphSet[glyphName]
+                if include(glyph) and filter_(glyph, glyphSet):
+                    modified.add(glyphName)
+
+        logger.debug("Took %.3fs to run %s on %d glyphs",
+                     t, self.name, len(modified))
         return modified

--- a/Lib/ufo2ft/filters/cubicToQuadratic.py
+++ b/Lib/ufo2ft/filters/cubicToQuadratic.py
@@ -5,6 +5,11 @@ from ufo2ft.filters import BaseFilter
 from cu2qu.ufo import DEFAULT_MAX_ERR
 from cu2qu.pens import Cu2QuPointPen
 
+import logging
+
+
+logger = logging.getLogger(__name__)
+
 
 class CubicToQuadraticFilter(BaseFilter):
 
@@ -17,6 +22,18 @@ class CubicToQuadraticFilter(BaseFilter):
     def start(self):
         relativeError = self.conversionError or DEFAULT_MAX_ERR
         self.absoluteError = relativeError * self.unitsPerEm
+        self.stats = None
+
+    def __call__(self, glyphSet):
+        self.stats = {}
+        if super(CubicToQuadraticFilter, self).__call__(glyphSet):
+            self.dump_stats()
+
+    def dump_stats(self):
+        stats = self.stats
+        logger.info('New spline lengths: %s' % (', '.join(
+                    '%s: %d' % (l, stats[l]) for l in sorted(stats.keys()))))
+        self.stats = None
 
     def filter(self, glyph, glyphSet=None):
         if not len(glyph):
@@ -25,7 +42,8 @@ class CubicToQuadraticFilter(BaseFilter):
         pen = Cu2QuPointPen(
             glyph.getPointPen(),
             self.absoluteError,
-            reverse_direction=self.reverseDirection)
+            reverse_direction=self.reverseDirection,
+            stats=self.stats)
         contours = list(glyph)
         glyph.clearContours()
         for contour in contours:

--- a/Lib/ufo2ft/filters/cubicToQuadratic.py
+++ b/Lib/ufo2ft/filters/cubicToQuadratic.py
@@ -1,0 +1,33 @@
+from __future__ import (
+    print_function, division, absolute_import, unicode_literals)
+
+from ufo2ft.filters import BaseFilter
+from cu2qu.ufo import DEFAULT_MAX_ERR
+from cu2qu.pens import Cu2QuPointPen
+
+
+class CubicToQuadraticFilter(BaseFilter):
+
+    _kwargs = {
+        'conversionError': None,
+        'unitsPerEm': 1000,
+        'reverseDirection': True,
+    }
+
+    def start(self):
+        relativeError = self.conversionError or DEFAULT_MAX_ERR
+        self.absoluteError = relativeError * self.unitsPerEm
+
+    def filter(self, glyph, glyphSet=None):
+        if not len(glyph):
+            return False
+
+        pen = Cu2QuPointPen(
+            glyph.getPointPen(),
+            self.absoluteError,
+            reverse_direction=self.reverseDirection)
+        contours = list(glyph)
+        glyph.clearContours()
+        for contour in contours:
+            contour.drawPoints(pen)
+        return True

--- a/Lib/ufo2ft/filters/decomposeComponents.py
+++ b/Lib/ufo2ft/filters/decomposeComponents.py
@@ -1,0 +1,39 @@
+from __future__ import (
+    print_function, division, absolute_import, unicode_literals)
+
+from fontTools.pens.reverseContourPen import ReverseContourPen
+from fontTools.misc.transform import Transform, Identity
+from fontTools.pens.transformPen import TransformPen
+from ufo2ft.filters import BaseFilter
+
+
+class DecomposeComponentsFilter(BaseFilter):
+
+    def filter(self, glyph, glyphSet=None):
+        if not glyph.components:
+            return False
+        _deepCopyContours(glyphSet, glyph, glyph, Transform())
+        glyph.clearComponents()
+        return True
+
+
+def _deepCopyContours(glyphSet, parent, component, transformation):
+    """Copy contours from component to parent, including nested components."""
+
+    for nested in component.components:
+        _deepCopyContours(
+            glyphSet, parent, glyphSet[nested.baseGlyph],
+            transformation.transform(nested.transformation))
+
+    if component != parent:
+        if transformation == Identity:
+            pen = parent.getPen()
+        else:
+            pen = TransformPen(parent.getPen(), transformation)
+            # if the transformation has a negative determinant, it will
+            # reverse the contour direction of the component
+            xx, xy, yx, yy = transformation[:4]
+            if xx*yy - xy*yx < 0:
+                pen = ReverseContourPen(pen)
+
+        component.draw(pen)

--- a/Lib/ufo2ft/filters/removeOverlaps.py
+++ b/Lib/ufo2ft/filters/removeOverlaps.py
@@ -1,0 +1,22 @@
+from __future__ import (
+    print_function, division, absolute_import, unicode_literals)
+
+from ufo2ft.filters import BaseFilter, logger
+from booleanOperations import union, BooleanOperationsError
+
+
+class RemoveOverlapsFilter(BaseFilter):
+
+    def filter(self, glyph, glyphSet=None):
+        if not len(glyph):
+            return False
+
+        contours = list(glyph)
+        glyph.clearContours()
+        try:
+            union(contours, glyph.getPointPen())
+        except BooleanOperationsError:
+            logger.error("Failed to remove overlaps for %s",
+                         glyph.name)
+            raise
+        return True

--- a/Lib/ufo2ft/filters/removeOverlaps.py
+++ b/Lib/ufo2ft/filters/removeOverlaps.py
@@ -1,8 +1,13 @@
 from __future__ import (
     print_function, division, absolute_import, unicode_literals)
 
-from ufo2ft.filters import BaseFilter, logger
+from ufo2ft.filters import BaseFilter
 from booleanOperations import union, BooleanOperationsError
+
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 class RemoveOverlapsFilter(BaseFilter):

--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -1050,11 +1050,15 @@ class OutlineTTFCompiler(BaseOutlineCompiler):
         for name in self.glyphOrder:
             glyph = allGlyphs[name]
             pen = TTGlyphPen(allGlyphs)
-            glyph.draw(pen)
-            ttGlyph = pen.glyph()
-            if ttGlyph.isComposite() and self.autoUseMyMetrics:
-                self.autoUseMyMetrics(ttGlyph, glyph.width, allGlyphs)
-            glyf[name] = ttGlyph
+            try:
+                glyph.draw(pen)
+            except NotImplementedError:
+                logger.error("%r has invalid curve format; skipped", name)
+            else:
+                ttGlyph = pen.glyph()
+                if ttGlyph.isComposite() and self.autoUseMyMetrics:
+                    self.autoUseMyMetrics(ttGlyph, glyph.width, allGlyphs)
+                glyf[name] = ttGlyph
 
     @staticmethod
     def autoUseMyMetrics(ttGlyph, width, glyphSet):

--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -12,7 +12,7 @@ from fontTools.pens.t2CharStringPen import T2CharStringPen
 from fontTools.pens.ttGlyphPen import TTGlyphPen
 from fontTools.ttLib.tables.O_S_2f_2 import Panose
 from fontTools.ttLib.tables._h_e_a_d import mac_epoch_diff
-from fontTools.ttLib.tables._g_l_y_f import USE_MY_METRICS
+from fontTools.ttLib.tables._g_l_y_f import Glyph, USE_MY_METRICS
 from fontTools.misc.arrayTools import unionRect
 
 from ufo2ft.fontInfoData import getAttrWithFallback, dateStringToTimeValue, dateStringForNow, intListToNum, normalizeStringForPostscript
@@ -1054,11 +1054,12 @@ class OutlineTTFCompiler(BaseOutlineCompiler):
                 glyph.draw(pen)
             except NotImplementedError:
                 logger.error("%r has invalid curve format; skipped", name)
+                ttGlyph = Glyph()
             else:
                 ttGlyph = pen.glyph()
                 if ttGlyph.isComposite() and self.autoUseMyMetrics:
                     self.autoUseMyMetrics(ttGlyph, glyph.width, allGlyphs)
-                glyf[name] = ttGlyph
+            glyf[name] = ttGlyph
 
     @staticmethod
     def autoUseMyMetrics(ttGlyph, width, glyphSet):

--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -7,7 +7,7 @@ from collections import Counter, namedtuple
 
 from fontTools.ttLib import TTFont, newTable
 from fontTools.cffLib import TopDictIndex, TopDict, CharStrings, SubrsIndex, GlobalSubrsIndex, PrivateDict, IndexedStrings
-from fontTools.pens.boundsPen import BoundsPen, ControlBoundsPen
+from fontTools.pens.boundsPen import ControlBoundsPen
 from fontTools.pens.t2CharStringPen import T2CharStringPen
 from fontTools.pens.ttGlyphPen import TTGlyphPen
 from fontTools.ttLib.tables.O_S_2f_2 import Panose

--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -45,22 +45,16 @@ class BaseOutlineCompiler(object):
 
     sfntVersion = None
 
-    def __init__(self, font, glyphOrder=None):
+    def __init__(self, font, glyphSet=None, glyphOrder=None):
         self.ufo = font
-        self.log = []
-        # make any missing glyphs and store them locally
-        missingRequiredGlyphs = self.makeMissingRequiredGlyphs()
-        # make a dict of all glyphs
-        self.allGlyphs = {}
-        for glyph in font:
-            self.allGlyphs[glyph.name] = glyph
-        self.allGlyphs.update(missingRequiredGlyphs)
+        # use the previously filtered glyphSet, if any
+        if glyphSet is None:
+            glyphSet = {g.name: g for g in font}
+        self.makeMissingRequiredGlyphs(font, glyphSet)
+        self.allGlyphs = glyphSet
         # store the glyph order
         if glyphOrder is None:
-            if hasattr(font, 'glyphOrder'):
-                glyphOrder = font.glyphOrder
-            else:
-                glyphOrder = sorted(self.allGlyphs.keys())
+            glyphOrder = font.glyphOrder
         self.glyphOrder = self.makeOfficialGlyphOrder(glyphOrder)
         # make reusable glyphs/font bounding boxes
         self.glyphBoundingBoxes = self.makeGlyphsBoundingBoxes()
@@ -111,11 +105,18 @@ class BaseOutlineCompiler(object):
         may override this method to handle the bounds creation
         in a different way if desired.
         """
+
+        def getControlPointBounds(glyph):
+            pen.init()
+            glyph.draw(pen)
+            return pen.bounds
+
         glyphBoxes = {}
+        pen = ControlBoundsPen(self.allGlyphs)
         for glyphName, glyph in self.allGlyphs.items():
             bounds = None
             if glyph or glyph.components:
-                bounds = glyph.controlPointBounds
+                bounds = getControlPointBounds(glyph)
                 if bounds:
                     bounds = BoundingBox(*(round(v) for v in bounds))
             glyphBoxes[glyphName] = bounds
@@ -158,42 +159,46 @@ class BaseOutlineCompiler(object):
                 mapping[uni] = glyphName
         return mapping
 
-    def makeMissingRequiredGlyphs(self):
+    @staticmethod
+    def makeMissingRequiredGlyphs(font, glyphSet):
         """
-        Add .notdef to the font if it is not present.
+        Add .notdef to the glyph set if it is not present.
 
         **This should not be called externally.** Subclasses
         may override this method to handle the glyph creation
         in a different way if desired.
         """
-        glyphs = {}
-        font = self.ufo
+        if ".notdef" in glyphSet:
+            return
+
         unitsPerEm = round(getAttrWithFallback(font.info, "unitsPerEm"))
         ascender = round(getAttrWithFallback(font.info, "ascender"))
         descender = round(getAttrWithFallback(font.info, "descender"))
         defaultWidth = round(unitsPerEm * 0.5)
-        if ".notdef" not in self.ufo:
-            glyphs[".notdef"] = StubGlyph(name=".notdef", width=defaultWidth, unitsPerEm=unitsPerEm, ascender=ascender, descender=descender)
-        return glyphs
+        glyphSet[".notdef"] = StubGlyph(name=".notdef",
+                                        width=defaultWidth,
+                                        unitsPerEm=unitsPerEm,
+                                        ascender=ascender,
+                                        descender=descender)
 
     def makeOfficialGlyphOrder(self, glyphOrder):
         """
-        Make a the final glyph order.
+        Make the final glyph order.
 
         **This should not be called externally.** Subclasses
         may override this method to handle the order creation
         in a different way if desired.
         """
-
         orderedGlyphs = [".notdef"]
         for glyphName in glyphOrder:
             if glyphName == ".notdef":
                 continue
-            if glyphName not in self.ufo:
+            if glyphName not in self.allGlyphs:
                 continue
             orderedGlyphs.append(glyphName)
+        orderedGlyphSet = set(orderedGlyphs)
         for glyphName in sorted(self.allGlyphs.keys()):
-            if glyphName not in orderedGlyphs:
+            if glyphName not in orderedGlyphSet:
                 orderedGlyphs.append(glyphName)
         return orderedGlyphs
 
@@ -778,13 +783,15 @@ class OutlineOTFCompiler(BaseOutlineCompiler):
 
     sfntVersion = "OTTO"
 
-    def __init__(self, font, glyphOrder=None, roundTolerance=None):
+    def __init__(self, font, glyphSet=None, glyphOrder=None,
+                 roundTolerance=None):
         if roundTolerance is not None:
             self.roundTolerance = float(roundTolerance)
         else:
             # round all coordinates to integers by default
             self.roundTolerance = 0.5
-        super(OutlineOTFCompiler, self).__init__(font, glyphOrder)
+        super(OutlineOTFCompiler, self).__init__(
+            font, glyphSet=glyphSet, glyphOrder=glyphOrder)
 
     def makeGlyphsBoundingBoxes(self):
         """
@@ -799,6 +806,11 @@ class OutlineOTFCompiler(BaseOutlineCompiler):
         values.
         """
 
+        def getControlPointBounds(glyph):
+            pen.init()
+            glyph.draw(pen)
+            return pen.bounds
+
         def toInt(value, else_callback):
             rounded = round(value)
             if tolerance >= 0.5 or abs(rounded - value) <= tolerance:
@@ -808,10 +820,11 @@ class OutlineOTFCompiler(BaseOutlineCompiler):
 
         tolerance = self.roundTolerance
         glyphBoxes = {}
+        pen = ControlBoundsPen(self.allGlyphs)
         for glyphName, glyph in self.allGlyphs.items():
             bounds = None
             if glyph or glyph.components:
-                bounds = glyph.controlPointBounds
+                bounds = getControlPointBounds(glyph)
                 if bounds:
                     rounded = []
                     for value in bounds[:2]:
@@ -891,7 +904,9 @@ class OutlineOTFCompiler(BaseOutlineCompiler):
         if trademark:
             trademark = normalizeStringForPostscript(trademark.replace("\u00A9", "Copyright"))
         if trademark != self.ufo.info.trademark:
-            self.log.append("[Warning] The trademark was normalized for storage in the CFF table and consequently some characters were dropped: '%s'" % trademark)
+            logger.warning("The trademark was normalized for storage in the "
+                           "CFF table and consequently some characters were "
+                           "dropped: '%s'", trademark)
         if trademark is None:
             trademark = ""
         topDict.Notice = trademark
@@ -899,7 +914,9 @@ class OutlineOTFCompiler(BaseOutlineCompiler):
         if copyright:
             copyright = normalizeStringForPostscript(copyright.replace("\u00A9", "Copyright"))
         if copyright != self.ufo.info.copyright:
-            self.log.append("[Warning] The copyright was normalized for storage in the CFF table and consequently some characters were dropped: '%s'" % copyright)
+            logger.warning("The copyright was normalized for storage in the "
+                           "CFF table and consequently some characters were "
+                           "dropped: '%s'", copyright)
         if copyright is None:
             copyright = ""
         topDict.Copyright = copyright
@@ -988,26 +1005,9 @@ class OutlineOTFCompiler(BaseOutlineCompiler):
 
 class OutlineTTFCompiler(BaseOutlineCompiler):
     """Compile a .ttf font with TrueType outlines.
-
-    If cubicConversionError is not specified, the default cu2qu error is
-    used. Currently, this is 1/1000 of the EM, or 0.001 * UPM.
-    If a value is specified, this should also be expressed as a fraction
-    of the UPM (e.g. 0.0005), and not in terms of absolute font units.
     """
 
     sfntVersion = "\000\001\000\000"
-
-    def __init__(self, font, glyphOrder=None, convertCubics=True,
-                 cubicConversionError=None):
-        super(OutlineTTFCompiler, self).__init__(font, glyphOrder)
-        if convertCubics:
-            unitsPerEm = getAttrWithFallback(font.info, "unitsPerEm")
-            if cubicConversionError is None:
-                from cu2qu.ufo import DEFAULT_MAX_ERR
-                cubicConversionError = DEFAULT_MAX_ERR
-            cubicConversionError *= unitsPerEm
-        self.convertCubics = convertCubics
-        self.cubicConversionError = cubicConversionError
 
     def setupTable_maxp(self):
         """Make the maxp table."""
@@ -1026,7 +1026,6 @@ class OutlineTTFCompiler(BaseOutlineCompiler):
 
     def setupTable_post(self):
         """Make a format 2 post table with the compiler's glyph order."""
-
         super(OutlineTTFCompiler, self).setupTable_post()
         post = self.otf["post"]
         post.formatType = 2.0
@@ -1042,27 +1041,12 @@ class OutlineTTFCompiler(BaseOutlineCompiler):
     def setupTable_glyf(self):
         """Make the glyf table."""
 
-        allGlyphs = self.allGlyphs
-        if self.convertCubics:
-            from cu2qu.pens import Cu2QuPen
-            allGlyphs = {}
-            for name, glyph in self.allGlyphs.items():
-                if isinstance(glyph, StubGlyph):
-                    allGlyphs[name] = glyph
-                    continue
-                newGlyph = glyph.__class__()
-                glyph.draw(Cu2QuPen(
-                    newGlyph.getPen(), self.cubicConversionError,
-                    reverse_direction=True))
-                # the width is needed for autoUseMyMetrics method below
-                newGlyph.width = glyph.width
-                allGlyphs[name] = newGlyph
-
         self.otf["loca"] = newTable("loca")
         self.otf["glyf"] = glyf = newTable("glyf")
         glyf.glyphs = {}
         glyf.glyphOrder = self.glyphOrder
 
+        allGlyphs = self.allGlyphs
         for name in self.glyphOrder:
             glyph = allGlyphs[name]
             pen = TTGlyphPen(allGlyphs)

--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -766,7 +766,11 @@ class BaseOutlineCompiler(object):
         in a different way if desired.
         """
         import os
+        import re
+
         prefix = "com.github.fonttools.ttx"
+        sfntVersionRE = re.compile('(^<ttFont\s+)(sfntVersion=".*"\s+)(.*>$)',
+                                   flags=re.MULTILINE)
         if not hasattr(self.ufo, "data"):
             return
         if not self.ufo.data.fileNames:
@@ -774,7 +778,11 @@ class BaseOutlineCompiler(object):
         for path in self.ufo.data.fileNames:
             foldername, filename = os.path.split(path)
             if (foldername == prefix and filename.endswith(".ttx")):
-                fp = BytesIO(self.ufo.data[path])
+                ttx = self.ufo.data[path].decode('utf-8')
+                # strip 'sfntVersion' attribute from ttFont element,
+                # if present, to avoid overwriting the current value
+                ttx = sfntVersionRE.sub(r'\1\3', ttx)
+                fp = BytesIO(ttx.encode('utf-8'))
                 self.otf.importXML(fp)
 
 

--- a/Lib/ufo2ft/preProcessor.py
+++ b/Lib/ufo2ft/preProcessor.py
@@ -1,0 +1,118 @@
+from __future__ import (
+    print_function, division, absolute_import, unicode_literals)
+
+from ufo2ft.filters import loadFilters
+from ufo2ft.filters.decomposeComponents import DecomposeComponentsFilter
+
+from copy import deepcopy
+
+
+class BasePreProcessor(object):
+    """Base class for objects that performs pre-processing operations on
+    the UFO glyphs, such as decomposing composites, removing overlaps, or
+    applying custom filters.
+
+    The input UFO is **not** modified. The ``process`` method returns a
+    dictionary containing the modified glyphset, keyed by glyph name.
+
+    Subclasses can override the ``initDefaultFilters`` method and return
+    a list of built-in filters which are performed in a predefined order,
+    between the user-defined pre- and post-filters.
+    The extra kwargs passed to the constructor can be used to customize the
+    initialization of the default filters.
+
+    Custom filters can be applied before or after the default filters.
+    These are specified in the UFO lib.plist under the private key
+    "com.github.googlei18n.ufo2ft.filters".
+    """
+
+    def __init__(self, ufo, **kwargs):
+        self.ufo = ufo
+        self.glyphSet = {g.name: _copyGlyph(g) for g in ufo}
+        self.defaultFilters = self.initDefaultFilters(**kwargs)
+        self.preFilters, self.postFilters = loadFilters(self.ufo)
+
+    def initDefaultFilters(self, **kwargs):
+        return []
+
+    def process(self):
+        glyphSet = self.glyphSet
+        for func in self.preFilters + self.defaultFilters + self.postFilters:
+            func(glyphSet)
+        return glyphSet
+
+
+class OTFPreProcessor(BasePreProcessor):
+    """Preprocessor for building CFF-flavored OpenType fonts.
+
+    By default, it decomposes all the components.
+
+    If ``removeOverlaps`` is True, it performs a union boolean operation on
+    all the glyphs' contours.
+    """
+
+    def initDefaultFilters(self, removeOverlaps=False):
+        filters = [DecomposeComponentsFilter()]
+        if removeOverlaps:
+            from ufo2ft.filters.removeOverlaps import RemoveOverlapsFilter
+            filters.append(RemoveOverlapsFilter())
+        return filters
+
+
+class TTFPreProcessor(OTFPreProcessor):
+    """Preprocessor for building TrueType-flavored OpenType fonts.
+
+    By default, it decomposes all the glyphs with mixed component/contour
+    outlines.
+
+    If ``removeOverlaps`` is True, it performs a union boolean operation on
+    all the glyphs' contours.
+
+    By default, it also converts all the PostScript cubic Bezier curves to
+    TrueType quadratic splines. If the outlines are already quadratic, you
+    can skip this by setting ``convertCubics`` to False.
+
+    The optional ``conversionError`` argument controls the tolerance
+    of the approximation algorithm. It is measured as the maximum distance
+    between the original and converted curve, and it's relative to the UPM
+    of the font (default: 1/1000 or 0.001).
+
+    When converting curves to quadratic, it is assumed that the contours'
+    winding direction is set following the PostScript counter-clockwise
+    convention. Thus, by default the direction is reversed, in order to
+    conform to opposite clockwise convention for TrueType outlines.
+    You can disable this by setting ``reverseDirection`` to False.
+    """
+
+    def initDefaultFilters(self, removeOverlaps=False, convertCubics=True,
+                           conversionError=None, reverseDirection=True):
+        # len(g) is the number of contours, so we include the all glyphs
+        # that have both components and at least one contour
+        filters = [DecomposeComponentsFilter(include=lambda g: len(g))]
+
+        if removeOverlaps:
+            from ufo2ft.filters.removeOverlaps import RemoveOverlapsFilter
+            filters.append(RemoveOverlapsFilter())
+
+        if convertCubics:
+            from ufo2ft.filters.cubicToQuadratic import CubicToQuadraticFilter
+            filters.append(
+                CubicToQuadraticFilter(conversionError=conversionError,
+                                       unitsPerEm=self.ufo.info.unitsPerEm,
+                                       reverseDirection=reverseDirection))
+
+        return filters
+
+
+def _copyGlyph(glyph):
+    # copy everything except unused attributes: 'guidelines', 'note', 'image'
+    copy = glyph.__class__()
+    copy.name = glyph.name
+    copy.width = glyph.width
+    copy.height = glyph.height
+    copy.unicodes = list(glyph.unicodes)
+    copy.anchors = [dict(a) for a in glyph.anchors]
+    copy.lib = deepcopy(glyph.lib)
+    pointPen = copy.getPointPen()
+    glyph.drawPoints(pointPen)
+    return copy

--- a/Lib/ufo2ft/preProcessor.py
+++ b/Lib/ufo2ft/preProcessor.py
@@ -12,8 +12,10 @@ class BasePreProcessor(object):
     the UFO glyphs, such as decomposing composites, removing overlaps, or
     applying custom filters.
 
-    The input UFO is **not** modified. The ``process`` method returns a
-    dictionary containing the modified glyphset, keyed by glyph name.
+    By default the input UFO is **not** modified. The ``process`` method
+    returns a dictionary containing the new modified glyphset, keyed by
+    glyph name. If ``inplace`` is True, the input UFO is modified directly
+    without the need to first copy the glyphs.
 
     Subclasses can override the ``initDefaultFilters`` method and return
     a list of built-in filters which are performed in a predefined order,
@@ -26,9 +28,12 @@ class BasePreProcessor(object):
     "com.github.googlei18n.ufo2ft.filters".
     """
 
-    def __init__(self, ufo, **kwargs):
+    def __init__(self, ufo, inplace=False, **kwargs):
         self.ufo = ufo
-        self.glyphSet = {g.name: _copyGlyph(g) for g in ufo}
+        if inplace:
+            self.glyphSet = {g.name: g for g in ufo}
+        else:
+            self.glyphSet = {g.name: _copyGlyph(g) for g in ufo}
         self.defaultFilters = self.initDefaultFilters(**kwargs)
         self.preFilters, self.postFilters = loadFilters(self.ufo)
 

--- a/Lib/ufo2ft/preProcessor.py
+++ b/Lib/ufo2ft/preProcessor.py
@@ -116,8 +116,9 @@ class TTFInterpolatablePreProcessor(object):
     The constructor takes a list of UFO fonts, and the ``process`` method
     returns the modified glyphsets (list of dicts) in the same order.
 
-    Currently, only the conversion from cubic to quadratic is performed,
-    and no additional filter is applied.
+    Currently, only the conversion from cubic to quadratic, and the
+    decomposition of mixed contour/component glyphs is performed,
+    and no additional custom filter is applied.
 
     The ``conversionError`` and ``reverseDirection`` arguments work in the
     same way as in the ``TTFPreProcessor``.
@@ -141,6 +142,11 @@ class TTFInterpolatablePreProcessor(object):
         fonts_to_quadratic(self.glyphSets, max_err=self._conversionErrors,
                            reverse_direction=self._reverseDirection,
                            dump_stats=True)
+
+        decompose = DecomposeComponentsFilter(include=lambda g: len(g))
+        for glyphSet in self.glyphSets:
+            decompose(glyphSet)
+
         return self.glyphSets
 
 

--- a/Lib/ufo2ft/preProcessor.py
+++ b/Lib/ufo2ft/preProcessor.py
@@ -139,7 +139,8 @@ class TTFInterpolatablePreProcessor(object):
         from cu2qu.ufo import fonts_to_quadratic
 
         fonts_to_quadratic(self.glyphSets, max_err=self._conversionErrors,
-                           reverse_direction=self._reverseDirection)
+                           reverse_direction=self._reverseDirection,
+                           dump_stats=True)
         return self.glyphSets
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-fonttools==3.15.0
+fonttools==3.17.0
 ufoLib==2.1.0
 defcon==0.3.4
 cu2qu==1.2.0
 compreffor==0.4.5
+booleanOperations==0.7.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.2
+current_version = 1.0.0.dev0
 commit = True
 tag = False
 tag_name = v{new_version}

--- a/setup.py
+++ b/setup.py
@@ -162,11 +162,12 @@ setup(
         'pytest>=2.8',
     ],
     install_requires=[
-        "fonttools>=3.15.0",
+        "fonttools>=3.17.0",
         "ufoLib>=2.1.0",
         "defcon>=0.3.4",
         "cu2qu>=1.2.0",
         "compreffor>=0.4.5",
+        "booleanOperations>=0.7.1",
     ],
     cmdclass={
         "release": release,

--- a/setup.py
+++ b/setup.py
@@ -145,7 +145,7 @@ with open('README.rst', 'r') as f:
 
 setup(
     name="ufo2ft",
-    version="0.6.2",
+    version="1.0.0.dev0",
     author="Tal Leming, James Godfrey-Kittle",
     author_email="tal@typesupply.com",
     maintainer="James Godfrey-Kittle",

--- a/tests/compiler_test.py
+++ b/tests/compiler_test.py
@@ -54,6 +54,14 @@ class CompilerTest(unittest.TestCase):
         self.expectTTX(compileTTF(loadUFO("MTIFeatures.ufo")),
                        "MTIFeatures.ttx", tables=self._layoutTables)
 
+    def test_removeOverlaps_CFF(self):
+        self.expectTTX(compileOTF(loadUFO("TestFont.ufo"), removeOverlaps=True),
+                       "TestFont-NoOverlaps-CFF.ttx")
+
+    def test_removeOverlaps(self):
+        self.expectTTX(compileTTF(loadUFO("TestFont.ufo"), removeOverlaps=True),
+                       "TestFont-NoOverlaps-TTF.ttx")
+
     def _temppath(self, suffix):
         if not self._tempdir:
             self._tempdir = tempfile.mkdtemp()

--- a/tests/compiler_test.py
+++ b/tests/compiler_test.py
@@ -2,7 +2,7 @@ from __future__ import \
     print_function, division, absolute_import, unicode_literals
 from fontTools.misc.py23 import *
 from defcon import Font
-from ufo2ft import compileOTF, compileTTF
+from ufo2ft import compileOTF, compileTTF, compileInterpolatableTTFs
 import difflib
 import os
 import sys
@@ -61,6 +61,13 @@ class CompilerTest(unittest.TestCase):
     def test_removeOverlaps(self):
         self.expectTTX(compileTTF(loadUFO("TestFont.ufo"), removeOverlaps=True),
                        "TestFont-NoOverlaps-TTF.ttx")
+
+    def test_interpolatableTTFs_lazy(self):
+        # two same UFOs **must** be interpolatable
+        ufos = [loadUFO("TestFont.ufo") for _ in range(2)]
+        ttfs = list(compileInterpolatableTTFs(ufos))
+        self.expectTTX(ttfs[0], "TestFont.ttx")
+        self.expectTTX(ttfs[1], "TestFont.ttx")
 
     def _temppath(self, suffix):
         if not self._tempdir:

--- a/tests/data/TestFont-CFF.ttx
+++ b/tests/data/TestFont-CFF.ttx
@@ -9,6 +9,14 @@
     <GlyphID id="3" name="uni0062"/>
     <GlyphID id="4" name="uni0063"/>
     <GlyphID id="5" name="uni0064"/>
+    <GlyphID id="6" name="uni0065"/>
+    <GlyphID id="7" name="uni0066"/>
+    <GlyphID id="8" name="uni0067"/>
+    <GlyphID id="9" name="uni0068"/>
+    <GlyphID id="10" name="uni0069"/>
+    <GlyphID id="11" name="uni006A"/>
+    <GlyphID id="12" name="uni006B"/>
+    <GlyphID id="13" name="uni006C"/>
   </GlyphOrder>
 
   <head>
@@ -21,9 +29,9 @@
     <unitsPerEm value="1000"/>
     <created value="Fri Feb 17 17:17:17 2017"/>
     <modified value="Sun Feb 18 18:18:18 2018"/>
-    <xMin value="50"/>
-    <yMin value="-10"/>
-    <xMax value="450"/>
+    <xMin value="-55"/>
+    <yMin value="-280"/>
+    <xMax value="454"/>
     <yMax value="750"/>
     <macStyle value="00000000 00000000"/>
     <lowestRecPPEM value="10"/>
@@ -37,10 +45,10 @@
     <ascent value="750"/>
     <descent value="-250"/>
     <lineGap value="200"/>
-    <advanceWidthMax value="500"/>
-    <minLeftSideBearing value="50"/>
-    <minRightSideBearing value="50"/>
-    <xMaxExtent value="450"/>
+    <advanceWidthMax value="600"/>
+    <minLeftSideBearing value="-55"/>
+    <minRightSideBearing value="-66"/>
+    <xMaxExtent value="454"/>
     <caretSlopeRise value="1"/>
     <caretSlopeRun value="0"/>
     <caretOffset value="0"/>
@@ -49,19 +57,19 @@
     <reserved2 value="0"/>
     <reserved3 value="0"/>
     <metricDataFormat value="0"/>
-    <numberOfHMetrics value="5"/>
+    <numberOfHMetrics value="11"/>
   </hhea>
 
   <maxp>
     <tableVersion value="0x5000"/>
-    <numGlyphs value="6"/>
+    <numGlyphs value="14"/>
   </maxp>
 
   <OS_2>
     <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
          will be recalculated by the compiler -->
     <version value="4"/>
-    <xAvgCharWidth value="383"/>
+    <xAvgCharWidth value="449"/>
     <usWeightClass value="500"/>
     <usWidthClass value="5"/>
     <fsType value="00000000 00000000"/>
@@ -95,7 +103,7 @@
     <achVendID value="SOME"/>
     <fsSelection value="00000000 01001000"/>
     <usFirstCharIndex value="32"/>
-    <usLastCharIndex value="100"/>
+    <usLastCharIndex value="108"/>
     <sTypoAscender value="750"/>
     <sTypoDescender value="-250"/>
     <sTypoLineGap value="200"/>
@@ -175,6 +183,14 @@
       <map code="0x62" name="uni0062"/><!-- LATIN SMALL LETTER B -->
       <map code="0x63" name="uni0063"/><!-- LATIN SMALL LETTER C -->
       <map code="0x64" name="uni0064"/><!-- LATIN SMALL LETTER D -->
+      <map code="0x65" name="uni0065"/><!-- LATIN SMALL LETTER E -->
+      <map code="0x66" name="uni0066"/><!-- LATIN SMALL LETTER F -->
+      <map code="0x67" name="uni0067"/><!-- LATIN SMALL LETTER G -->
+      <map code="0x68" name="uni0068"/><!-- LATIN SMALL LETTER H -->
+      <map code="0x69" name="uni0069"/><!-- LATIN SMALL LETTER I -->
+      <map code="0x6a" name="uni006A"/><!-- LATIN SMALL LETTER J -->
+      <map code="0x6b" name="uni006B"/><!-- LATIN SMALL LETTER K -->
+      <map code="0x6c" name="uni006C"/><!-- LATIN SMALL LETTER L -->
     </cmap_format_4>
     <cmap_format_4 platformID="3" platEncID="1" language="0">
       <map code="0x20" name="uni0020"/><!-- SPACE -->
@@ -182,6 +198,14 @@
       <map code="0x62" name="uni0062"/><!-- LATIN SMALL LETTER B -->
       <map code="0x63" name="uni0063"/><!-- LATIN SMALL LETTER C -->
       <map code="0x64" name="uni0064"/><!-- LATIN SMALL LETTER D -->
+      <map code="0x65" name="uni0065"/><!-- LATIN SMALL LETTER E -->
+      <map code="0x66" name="uni0066"/><!-- LATIN SMALL LETTER F -->
+      <map code="0x67" name="uni0067"/><!-- LATIN SMALL LETTER G -->
+      <map code="0x68" name="uni0068"/><!-- LATIN SMALL LETTER H -->
+      <map code="0x69" name="uni0069"/><!-- LATIN SMALL LETTER I -->
+      <map code="0x6a" name="uni006A"/><!-- LATIN SMALL LETTER J -->
+      <map code="0x6b" name="uni006B"/><!-- LATIN SMALL LETTER K -->
+      <map code="0x6c" name="uni006C"/><!-- LATIN SMALL LETTER L -->
     </cmap_format_4>
   </cmap>
 
@@ -215,7 +239,7 @@
       <PaintType value="0"/>
       <CharstringType value="2"/>
       <FontMatrix value="0.001 0 0 0.001 0 0"/>
-      <FontBBox value="50 -10 450 750"/>
+      <FontBBox value="-55 -280 454 750"/>
       <StrokeWidth value="0"/>
       <!-- charset is dumped separately as the 'GlyphOrder' element -->
       <Encoding name="StandardEncoding"/>
@@ -237,6 +261,31 @@
         <initialRandomSeed value="0"/>
         <defaultWidthX value="400"/>
         <nominalWidthX value="400"/>
+        <Subrs>
+          <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
+          <CharString index="0">
+            256 hlineto
+            -128 510 rlineto
+            endchar
+          </CharString>
+          <CharString index="1">
+            200 -55 -80 rmoveto
+            509 hlineto
+            149 -50 50 -205 -204 -50 -50 -149 vhcurveto
+            121 return
+          </CharString>
+          <CharString index="2">
+            rmoveto
+            509 hlineto
+            150 -50 50 -205 -204 -50 -50 -150 vhcurveto
+            endchar
+          </CharString>
+          <CharString index="3">
+            rmoveto
+            -34 -27 -27 -33 -33 27 -27 34 33 27 27 33 33 -27 27 -33 hvcurveto
+            return
+          </CharString>
+        </Subrs>
       </Private>
       <CharStrings>
         <CharString name=".notdef">
@@ -251,23 +300,67 @@
         </CharString>
         <CharString name="uni0061">
           -12 66 hmoveto
-          128 510 128 -510 rlineto
-          endchar
+          -107 callsubr
         </CharString>
         <CharString name="uni0062">
           10 100 505 rmoveto
-          210 -510 -210 hlineto
+          -510 210 510 vlineto
           endchar
         </CharString>
         <CharString name="uni0063">
           -26 300 -10 rmoveto
-          -150 -50 50 205 205 50 50 150 hvcurveto
+          510 vlineto
+          -150 -50 -50 -205 -205 50 -50 150 hvcurveto
           endchar
         </CharString>
         <CharString name="uni0064">
-          -26 151 197 rmoveto
-          -34 -27 -27 -33 -33 27 -27 34 33 27 27 33 33 -27 27 -33 hvcurveto
+          -26 151 197 -104 callsubr
           endchar
+        </CharString>
+        <CharString name="uni0065">
+          -12 66 510 rmoveto
+          128 -435 128 435 rlineto
+          -377 -487 -105 callsubr
+        </CharString>
+        <CharString name="uni0066">
+          10 66 510 rmoveto
+          256 hlineto
+          -128 -435 rlineto
+          -249 -52 -105 callsubr
+        </CharString>
+        <CharString name="uni0067">
+          -12 66 hmoveto
+          -107 callsubr
+        </CharString>
+        <CharString name="uni0068">
+          10 211 657 -104 callsubr
+          -111 -152 rmoveto
+          -510 210 510 vlineto
+          endchar
+        </CharString>
+        <CharString name="uni0069">
+          -106 callsubr
+          80 rmoveto
+          -107 callsubr
+        </CharString>
+        <CharString name="uni006A">
+          -106 callsubr
+          310 rmoveto
+          128 -510 128 510 rlineto
+          endchar
+        </CharString>
+        <CharString name="uni006B">
+          200 66 hmoveto
+          256 hlineto
+          -128 510 rlineto
+          -28 -510 rmoveto
+          -107 callsubr
+        </CharString>
+        <CharString name="uni006C">
+          200 334 hmoveto
+          -128 510 -128 -510 rlineto
+          88 hmoveto
+          -107 callsubr
         </CharString>
       </CharStrings>
     </CFFFont>
@@ -279,7 +372,7 @@
 
   <CUST raw="True">
     <hexdata>
-      0001beef
+      0001beef   
     </hexdata>
   </CUST>
 
@@ -357,6 +450,14 @@
     <mtx name="uni0062" width="410" lsb="100"/>
     <mtx name="uni0063" width="374" lsb="100"/>
     <mtx name="uni0064" width="374" lsb="90"/>
+    <mtx name="uni0065" width="388" lsb="-55"/>
+    <mtx name="uni0066" width="410" lsb="-55"/>
+    <mtx name="uni0067" width="388" lsb="66"/>
+    <mtx name="uni0068" width="410" lsb="100"/>
+    <mtx name="uni0069" width="600" lsb="-55"/>
+    <mtx name="uni006A" width="600" lsb="-55"/>
+    <mtx name="uni006B" width="600" lsb="66"/>
+    <mtx name="uni006C" width="600" lsb="78"/>
   </hmtx>
 
 </ttFont>

--- a/tests/data/TestFont-NoOverlaps-CFF.ttx
+++ b/tests/data/TestFont-NoOverlaps-CFF.ttx
@@ -1,0 +1,465 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="OTTO">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="uni0020"/>
+    <GlyphID id="2" name="uni0061"/>
+    <GlyphID id="3" name="uni0062"/>
+    <GlyphID id="4" name="uni0063"/>
+    <GlyphID id="5" name="uni0064"/>
+    <GlyphID id="6" name="uni0065"/>
+    <GlyphID id="7" name="uni0066"/>
+    <GlyphID id="8" name="uni0067"/>
+    <GlyphID id="9" name="uni0068"/>
+    <GlyphID id="10" name="uni0069"/>
+    <GlyphID id="11" name="uni006A"/>
+    <GlyphID id="12" name="uni006B"/>
+    <GlyphID id="13" name="uni006C"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="1.0"/>
+    <checkSumAdjustment value="0x12345678"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Fri Feb 17 17:17:17 2017"/>
+    <modified value="Sun Feb 18 18:18:18 2018"/>
+    <xMin value="-55"/>
+    <yMin value="-280"/>
+    <xMax value="454"/>
+    <yMax value="750"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="10"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="750"/>
+    <descent value="-250"/>
+    <lineGap value="200"/>
+    <advanceWidthMax value="600"/>
+    <minLeftSideBearing value="-55"/>
+    <minRightSideBearing value="-66"/>
+    <xMaxExtent value="454"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="11"/>
+  </hhea>
+
+  <maxp>
+    <tableVersion value="0x5000"/>
+    <numGlyphs value="14"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="4"/>
+    <xAvgCharWidth value="449"/>
+    <usWeightClass value="500"/>
+    <usWidthClass value="5"/>
+    <fsType value="00000000 00000000"/>
+    <ySubscriptXSize value="200"/>
+    <ySubscriptYSize value="400"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="-100"/>
+    <ySuperscriptXSize value="200"/>
+    <ySuperscriptYSize value="400"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="200"/>
+    <yStrikeoutSize value="20"/>
+    <yStrikeoutPosition value="300"/>
+    <sFamilyClass value="257"/>
+    <panose>
+      <bFamilyType value="0"/>
+      <bSerifStyle value="1"/>
+      <bWeight value="2"/>
+      <bProportion value="3"/>
+      <bContrast value="4"/>
+      <bStrokeVariation value="5"/>
+      <bArmStyle value="6"/>
+      <bLetterForm value="7"/>
+      <bMidline value="8"/>
+      <bXHeight value="9"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00000000 00000011"/>
+    <ulUnicodeRange2 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="SOME"/>
+    <fsSelection value="00000000 01001000"/>
+    <usFirstCharIndex value="32"/>
+    <usLastCharIndex value="108"/>
+    <sTypoAscender value="750"/>
+    <sTypoDescender value="-250"/>
+    <sTypoLineGap value="200"/>
+    <usWinAscent value="750"/>
+    <usWinDescent value="250"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000011"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="500"/>
+    <sCapHeight value="750"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="2"/>
+  </OS_2>
+
+  <name>
+    <namerecord nameID="3" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Unique Font Identifier
+    </namerecord>
+    <namerecord nameID="0" platformID="3" platEncID="1" langID="0x409">
+      Copyright © Some Foundry.
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      Some Font Regular (Style Map Family Name)
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      OpenType name Table Unique ID
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      Some Font (Preferred Family Name) Regular (Preferred Subfamily Name)
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      OpenType name Table Version
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      SomeFont-Regular Postscript Font Name
+    </namerecord>
+    <namerecord nameID="7" platformID="3" platEncID="1" langID="0x409">
+      Trademark Some Foundry
+    </namerecord>
+    <namerecord nameID="8" platformID="3" platEncID="1" langID="0x409">
+      Some Foundry (Manufacturer Name)
+    </namerecord>
+    <namerecord nameID="9" platformID="3" platEncID="1" langID="0x409">
+      Some Designer
+    </namerecord>
+    <namerecord nameID="10" platformID="3" platEncID="1" langID="0x409">
+      Some Font by Some Designer for Some Foundry.
+    </namerecord>
+    <namerecord nameID="11" platformID="3" platEncID="1" langID="0x409">
+      http://somefoundry.com
+    </namerecord>
+    <namerecord nameID="12" platformID="3" platEncID="1" langID="0x409">
+      http://somedesigner.com
+    </namerecord>
+    <namerecord nameID="13" platformID="3" platEncID="1" langID="0x409">
+      License info for Some Foundry.
+    </namerecord>
+    <namerecord nameID="14" platformID="3" platEncID="1" langID="0x409">
+      http://somefoundry.com/license
+    </namerecord>
+    <namerecord nameID="16" platformID="3" platEncID="1" langID="0x409">
+      Some Font (Preferred Family Name)
+    </namerecord>
+    <namerecord nameID="17" platformID="3" platEncID="1" langID="0x409">
+      Regular (Preferred Subfamily Name)
+    </namerecord>
+  </name>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+      <map code="0x20" name="uni0020"/><!-- SPACE -->
+      <map code="0x61" name="uni0061"/><!-- LATIN SMALL LETTER A -->
+      <map code="0x62" name="uni0062"/><!-- LATIN SMALL LETTER B -->
+      <map code="0x63" name="uni0063"/><!-- LATIN SMALL LETTER C -->
+      <map code="0x64" name="uni0064"/><!-- LATIN SMALL LETTER D -->
+      <map code="0x65" name="uni0065"/><!-- LATIN SMALL LETTER E -->
+      <map code="0x66" name="uni0066"/><!-- LATIN SMALL LETTER F -->
+      <map code="0x67" name="uni0067"/><!-- LATIN SMALL LETTER G -->
+      <map code="0x68" name="uni0068"/><!-- LATIN SMALL LETTER H -->
+      <map code="0x69" name="uni0069"/><!-- LATIN SMALL LETTER I -->
+      <map code="0x6a" name="uni006A"/><!-- LATIN SMALL LETTER J -->
+      <map code="0x6b" name="uni006B"/><!-- LATIN SMALL LETTER K -->
+      <map code="0x6c" name="uni006C"/><!-- LATIN SMALL LETTER L -->
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+      <map code="0x20" name="uni0020"/><!-- SPACE -->
+      <map code="0x61" name="uni0061"/><!-- LATIN SMALL LETTER A -->
+      <map code="0x62" name="uni0062"/><!-- LATIN SMALL LETTER B -->
+      <map code="0x63" name="uni0063"/><!-- LATIN SMALL LETTER C -->
+      <map code="0x64" name="uni0064"/><!-- LATIN SMALL LETTER D -->
+      <map code="0x65" name="uni0065"/><!-- LATIN SMALL LETTER E -->
+      <map code="0x66" name="uni0066"/><!-- LATIN SMALL LETTER F -->
+      <map code="0x67" name="uni0067"/><!-- LATIN SMALL LETTER G -->
+      <map code="0x68" name="uni0068"/><!-- LATIN SMALL LETTER H -->
+      <map code="0x69" name="uni0069"/><!-- LATIN SMALL LETTER I -->
+      <map code="0x6a" name="uni006A"/><!-- LATIN SMALL LETTER J -->
+      <map code="0x6b" name="uni006B"/><!-- LATIN SMALL LETTER K -->
+      <map code="0x6c" name="uni006C"/><!-- LATIN SMALL LETTER L -->
+    </cmap_format_4>
+  </cmap>
+
+  <post>
+    <formatType value="3.0"/>
+    <italicAngle value="-12.5"/>
+    <underlinePosition value="-200"/>
+    <underlineThickness value="20"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+  </post>
+
+  <CFF>
+    <major value="1"/>
+    <minor value="0"/>
+    <CFFFont name="SomeFont-Regular (Postscript Font Name)">
+      <version value="1.0"/>
+      <Notice value="Trademark Some Foundry"/>
+      <Copyright value="Copyright Copyright Some Foundry."/>
+      <FullName value="Some Font-Regular (Postscript Full Name)"/>
+      <FontName value="SomeFont-Regular (Postscript Font Name)"/>
+      <FamilyName value="Some Font (Preferred Family Name)"/>
+      <Weight value="Medium"/>
+      <isFixedPitch value="0"/>
+      <ItalicAngle value="-12.5"/>
+      <UnderlinePosition value="-200"/>
+      <UnderlineThickness value="20"/>
+      <PaintType value="0"/>
+      <CharstringType value="2"/>
+      <FontMatrix value="0.001 0 0 0.001 0 0"/>
+      <FontBBox value="-55 -280 454 750"/>
+      <StrokeWidth value="0"/>
+      <!-- charset is dumped separately as the 'GlyphOrder' element -->
+      <Encoding name="StandardEncoding"/>
+      <Private>
+        <BlueValues value="500 510"/>
+        <OtherBlues value="-250 -260"/>
+        <FamilyBlues value="500 510"/>
+        <FamilyOtherBlues value="-250 -260"/>
+        <BlueScale value="0.039625"/>
+        <BlueShift value="7"/>
+        <BlueFuzz value="1"/>
+        <StdHW value="100"/>
+        <StdVW value="80"/>
+        <StemSnapH value="100 120"/>
+        <StemSnapV value="80 90"/>
+        <ForceBold value="1"/>
+        <LanguageGroup value="0"/>
+        <ExpansionFactor value="0.06"/>
+        <initialRandomSeed value="0"/>
+        <defaultWidthX value="400"/>
+        <nominalWidthX value="400"/>
+        <Subrs>
+          <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
+          <CharString index="0">
+            -55 23 rmoveto
+            509 hlineto
+            140 -44 53 -173 6 vhcurveto
+            85 288 -256 0 85 -288 rlineto
+            -164 -8 -42 -54 -137 vvcurveto
+            return
+          </CharString>
+          <CharString index="1">
+            rmoveto
+            -34 -27 -27 -33 -33 27 -27 34 33 27 27 33 33 -27 27 -33 hvcurveto
+            return
+          </CharString>
+        </Subrs>
+      </Private>
+      <CharStrings>
+        <CharString name=".notdef">
+          100 450 hmoveto
+          750 -400 -750 vlineto
+          350 50 rmoveto
+          -300 650 300 hlineto
+          endchar
+        </CharString>
+        <CharString name="uni0020">
+          -150 endchar
+        </CharString>
+        <CharString name="uni0061">
+          -12 66 hmoveto
+          256 hlineto
+          -128 510 rlineto
+          endchar
+        </CharString>
+        <CharString name="uni0062">
+          10 100 505 rmoveto
+          -510 210 510 vlineto
+          endchar
+        </CharString>
+        <CharString name="uni0063">
+          -26 300 -10 rmoveto
+          510 vlineto
+          -150 -50 -50 -205 -205 50 -50 150 hvcurveto
+          endchar
+        </CharString>
+        <CharString name="uni0064">
+          -26 151 197 -106 callsubr
+          endchar
+        </CharString>
+        <CharString name="uni0065">
+          -12 -107 callsubr
+          endchar
+        </CharString>
+        <CharString name="uni0066">
+          10 -107 callsubr
+          254 200 rmoveto
+          13 13 0 -1 12 hvcurveto
+          -43 -147 -43 147 rlineto
+          1 15 16 0 17 hhcurveto
+          endchar
+        </CharString>
+        <CharString name="uni0067">
+          -12 66 hmoveto
+          256 hlineto
+          -128 510 rlineto
+          endchar
+        </CharString>
+        <CharString name="uni0068">
+          10 211 657 -106 callsubr
+          -111 -152 rmoveto
+          -510 210 510 vlineto
+          endchar
+        </CharString>
+        <CharString name="uni0069">
+          200 -55 -80 rmoveto
+          509 hlineto
+          123 -34 55 -127 16 vhcurveto
+          -99 396 -100 -397 rlineto
+          -117 -18 -32 -56 -119 vvcurveto
+          endchar
+        </CharString>
+        <CharString name="uni006A">
+          200 -55 -80 rmoveto
+          199 hlineto
+          50 -200 50 200 rlineto
+          210 hlineto
+          123 -34 55 -127 16 vhcurveto
+          29 116 -256 0 29 -117 rlineto
+          -118 -18 -32 -55 -120 vvcurveto
+          endchar
+        </CharString>
+        <CharString name="uni006B">
+          200 66 hmoveto
+          356 hlineto
+          -128 510 -50 -199 -50 199 rlineto
+          endchar
+        </CharString>
+        <CharString name="uni006C">
+          200 294 510 rmoveto
+          -44 -175 -44 175 -128 -510 rlineto
+          344 hlineto
+          endchar
+        </CharString>
+      </CharStrings>
+    </CFFFont>
+
+    <GlobalSubrs>
+      <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
+    </GlobalSubrs>
+  </CFF>
+
+  <CUST raw="True">
+    <hexdata>
+      0001beef   
+    </hexdata>
+  </CUST>
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="kern"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="2"/>
+        <LookupFlag value="8"/>
+        <!-- SubTableCount=1 -->
+        <PairPos index="0" Format="1">
+          <Coverage Format="1">
+            <Glyph value="uni0061"/>
+            <Glyph value="uni0062"/>
+          </Coverage>
+          <ValueFormat1 value="4"/>
+          <ValueFormat2 value="0"/>
+          <!-- PairSetCount=2 -->
+          <PairSet index="0">
+            <!-- PairValueCount=3 -->
+            <PairValueRecord index="0">
+              <SecondGlyph value="uni0020"/>
+              <Value1 XAdvance="1"/>
+            </PairValueRecord>
+            <PairValueRecord index="1">
+              <SecondGlyph value="uni0061"/>
+              <Value1 XAdvance="5"/>
+            </PairValueRecord>
+            <PairValueRecord index="2">
+              <SecondGlyph value="uni0062"/>
+              <Value1 XAdvance="-10"/>
+            </PairValueRecord>
+          </PairSet>
+          <PairSet index="1">
+            <!-- PairValueCount=1 -->
+            <PairValueRecord index="0">
+              <SecondGlyph value="uni0061"/>
+              <Value1 XAdvance="-7"/>
+            </PairValueRecord>
+          </PairSet>
+        </PairPos>
+      </Lookup>
+    </LookupList>
+  </GPOS>
+
+  <hmtx>
+    <mtx name=".notdef" width="500" lsb="50"/>
+    <mtx name="uni0020" width="250" lsb="0"/>
+    <mtx name="uni0061" width="388" lsb="66"/>
+    <mtx name="uni0062" width="410" lsb="100"/>
+    <mtx name="uni0063" width="374" lsb="100"/>
+    <mtx name="uni0064" width="374" lsb="90"/>
+    <mtx name="uni0065" width="388" lsb="-55"/>
+    <mtx name="uni0066" width="410" lsb="-55"/>
+    <mtx name="uni0067" width="388" lsb="66"/>
+    <mtx name="uni0068" width="410" lsb="100"/>
+    <mtx name="uni0069" width="600" lsb="-55"/>
+    <mtx name="uni006A" width="600" lsb="-55"/>
+    <mtx name="uni006B" width="600" lsb="66"/>
+    <mtx name="uni006C" width="600" lsb="78"/>
+  </hmtx>
+
+</ttFont>

--- a/tests/data/TestFont-NoOverlaps-TTF.ttx
+++ b/tests/data/TestFont-NoOverlaps-TTF.ttx
@@ -1,0 +1,540 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="\x00\x01\x00\x00">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="uni0020"/>
+    <GlyphID id="2" name="uni0061"/>
+    <GlyphID id="3" name="uni0062"/>
+    <GlyphID id="4" name="uni0063"/>
+    <GlyphID id="5" name="uni0064"/>
+    <GlyphID id="6" name="uni0065"/>
+    <GlyphID id="7" name="uni0066"/>
+    <GlyphID id="8" name="uni0067"/>
+    <GlyphID id="9" name="uni0068"/>
+    <GlyphID id="10" name="uni0069"/>
+    <GlyphID id="11" name="uni006A"/>
+    <GlyphID id="12" name="uni006B"/>
+    <GlyphID id="13" name="uni006C"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="1.0"/>
+    <checkSumAdjustment value="0x12345678"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Fri Feb 17 17:17:17 2017"/>
+    <modified value="Sun Feb 18 18:18:18 2018"/>
+    <xMin value="-55"/>
+    <yMin value="-280"/>
+    <xMax value="454"/>
+    <yMax value="750"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="10"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="750"/>
+    <descent value="-250"/>
+    <lineGap value="200"/>
+    <advanceWidthMax value="600"/>
+    <minLeftSideBearing value="-55"/>
+    <minRightSideBearing value="-66"/>
+    <xMaxExtent value="454"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="11"/>
+  </hhea>
+
+  <maxp>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="0x10000"/>
+    <numGlyphs value="14"/>
+    <maxPoints value="18"/>
+    <maxContours value="2"/>
+    <maxCompositePoints value="16"/>
+    <maxCompositeContours value="2"/>
+    <maxZones value="1"/>
+    <maxTwilightPoints value="0"/>
+    <maxStorage value="0"/>
+    <maxFunctionDefs value="0"/>
+    <maxInstructionDefs value="0"/>
+    <maxStackElements value="0"/>
+    <maxSizeOfInstructions value="0"/>
+    <maxComponentElements value="2"/>
+    <maxComponentDepth value="1"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="4"/>
+    <xAvgCharWidth value="449"/>
+    <usWeightClass value="500"/>
+    <usWidthClass value="5"/>
+    <fsType value="00000000 00000000"/>
+    <ySubscriptXSize value="200"/>
+    <ySubscriptYSize value="400"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="-100"/>
+    <ySuperscriptXSize value="200"/>
+    <ySuperscriptYSize value="400"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="200"/>
+    <yStrikeoutSize value="20"/>
+    <yStrikeoutPosition value="300"/>
+    <sFamilyClass value="257"/>
+    <panose>
+      <bFamilyType value="0"/>
+      <bSerifStyle value="1"/>
+      <bWeight value="2"/>
+      <bProportion value="3"/>
+      <bContrast value="4"/>
+      <bStrokeVariation value="5"/>
+      <bArmStyle value="6"/>
+      <bLetterForm value="7"/>
+      <bMidline value="8"/>
+      <bXHeight value="9"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00000000 00000011"/>
+    <ulUnicodeRange2 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="SOME"/>
+    <fsSelection value="00000000 01001000"/>
+    <usFirstCharIndex value="32"/>
+    <usLastCharIndex value="108"/>
+    <sTypoAscender value="750"/>
+    <sTypoDescender value="-250"/>
+    <sTypoLineGap value="200"/>
+    <usWinAscent value="750"/>
+    <usWinDescent value="250"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000011"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="500"/>
+    <sCapHeight value="750"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="2"/>
+  </OS_2>
+
+  <hmtx>
+    <mtx name=".notdef" width="500" lsb="50"/>
+    <mtx name="uni0020" width="250" lsb="0"/>
+    <mtx name="uni0061" width="388" lsb="66"/>
+    <mtx name="uni0062" width="410" lsb="100"/>
+    <mtx name="uni0063" width="374" lsb="100"/>
+    <mtx name="uni0064" width="374" lsb="90"/>
+    <mtx name="uni0065" width="388" lsb="-55"/>
+    <mtx name="uni0066" width="410" lsb="-55"/>
+    <mtx name="uni0067" width="388" lsb="66"/>
+    <mtx name="uni0068" width="410" lsb="100"/>
+    <mtx name="uni0069" width="600" lsb="-55"/>
+    <mtx name="uni006A" width="600" lsb="-55"/>
+    <mtx name="uni006B" width="600" lsb="66"/>
+    <mtx name="uni006C" width="600" lsb="78"/>
+  </hmtx>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+      <map code="0x20" name="uni0020"/><!-- SPACE -->
+      <map code="0x61" name="uni0061"/><!-- LATIN SMALL LETTER A -->
+      <map code="0x62" name="uni0062"/><!-- LATIN SMALL LETTER B -->
+      <map code="0x63" name="uni0063"/><!-- LATIN SMALL LETTER C -->
+      <map code="0x64" name="uni0064"/><!-- LATIN SMALL LETTER D -->
+      <map code="0x65" name="uni0065"/><!-- LATIN SMALL LETTER E -->
+      <map code="0x66" name="uni0066"/><!-- LATIN SMALL LETTER F -->
+      <map code="0x67" name="uni0067"/><!-- LATIN SMALL LETTER G -->
+      <map code="0x68" name="uni0068"/><!-- LATIN SMALL LETTER H -->
+      <map code="0x69" name="uni0069"/><!-- LATIN SMALL LETTER I -->
+      <map code="0x6a" name="uni006A"/><!-- LATIN SMALL LETTER J -->
+      <map code="0x6b" name="uni006B"/><!-- LATIN SMALL LETTER K -->
+      <map code="0x6c" name="uni006C"/><!-- LATIN SMALL LETTER L -->
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+      <map code="0x20" name="uni0020"/><!-- SPACE -->
+      <map code="0x61" name="uni0061"/><!-- LATIN SMALL LETTER A -->
+      <map code="0x62" name="uni0062"/><!-- LATIN SMALL LETTER B -->
+      <map code="0x63" name="uni0063"/><!-- LATIN SMALL LETTER C -->
+      <map code="0x64" name="uni0064"/><!-- LATIN SMALL LETTER D -->
+      <map code="0x65" name="uni0065"/><!-- LATIN SMALL LETTER E -->
+      <map code="0x66" name="uni0066"/><!-- LATIN SMALL LETTER F -->
+      <map code="0x67" name="uni0067"/><!-- LATIN SMALL LETTER G -->
+      <map code="0x68" name="uni0068"/><!-- LATIN SMALL LETTER H -->
+      <map code="0x69" name="uni0069"/><!-- LATIN SMALL LETTER I -->
+      <map code="0x6a" name="uni006A"/><!-- LATIN SMALL LETTER J -->
+      <map code="0x6b" name="uni006B"/><!-- LATIN SMALL LETTER K -->
+      <map code="0x6c" name="uni006C"/><!-- LATIN SMALL LETTER L -->
+    </cmap_format_4>
+  </cmap>
+
+  <loca>
+    <!-- The 'loca' table will be calculated by the compiler -->
+  </loca>
+
+  <glyf>
+
+    <!-- The xMin, yMin, xMax and yMax values
+         will be recalculated by the compiler. -->
+
+    <TTGlyph name=".notdef" xMin="50" yMin="0" xMax="450" yMax="750">
+      <contour>
+        <pt x="450" y="0" on="1"/>
+        <pt x="50" y="0" on="1"/>
+        <pt x="50" y="750" on="1"/>
+        <pt x="450" y="750" on="1"/>
+      </contour>
+      <contour>
+        <pt x="400" y="50" on="1"/>
+        <pt x="400" y="700" on="1"/>
+        <pt x="100" y="700" on="1"/>
+        <pt x="100" y="50" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="uni0020"/><!-- contains no outline data -->
+
+    <TTGlyph name="uni0061" xMin="66" yMin="0" xMax="322" yMax="510">
+      <contour>
+        <pt x="66" y="0" on="1"/>
+        <pt x="194" y="510" on="1"/>
+        <pt x="322" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="uni0062" xMin="100" yMin="-5" xMax="310" yMax="505">
+      <contour>
+        <pt x="100" y="505" on="1"/>
+        <pt x="310" y="505" on="1"/>
+        <pt x="310" y="-5" on="1"/>
+        <pt x="100" y="-5" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="uni0063" xMin="100" yMin="-10" xMax="300" yMax="500">
+      <contour>
+        <pt x="300" y="-10" on="1"/>
+        <pt x="225" y="-10" on="0"/>
+        <pt x="138" y="32" on="0"/>
+        <pt x="100" y="142" on="0"/>
+        <pt x="100" y="245" on="1"/>
+        <pt x="100" y="348" on="0"/>
+        <pt x="138" y="458" on="0"/>
+        <pt x="225" y="500" on="0"/>
+        <pt x="300" y="500" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="uni0064" xMin="90" yMin="77" xMax="211" yMax="197">
+      <contour>
+        <pt x="151" y="197" on="1"/>
+        <pt x="176" y="197" on="0"/>
+        <pt x="211" y="162" on="0"/>
+        <pt x="211" y="137" on="1"/>
+        <pt x="211" y="112" on="0"/>
+        <pt x="176" y="77" on="0"/>
+        <pt x="151" y="77" on="1"/>
+        <pt x="125" y="77" on="0"/>
+        <pt x="90" y="112" on="0"/>
+        <pt x="90" y="137" on="1"/>
+        <pt x="90" y="162" on="0"/>
+        <pt x="125" y="197" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="uni0065" xMin="-55" yMin="23" xMax="454" yMax="510">
+      <contour>
+        <pt x="-55" y="23" on="1"/>
+        <pt x="-55" y="92" on="0"/>
+        <pt x="-20" y="176" on="0"/>
+        <pt x="69" y="218" on="0"/>
+        <pt x="151" y="222" on="1"/>
+        <pt x="66" y="510" on="1"/>
+        <pt x="322" y="510" on="1"/>
+        <pt x="237" y="222" on="1"/>
+        <pt x="324" y="219" on="0"/>
+        <pt x="418" y="178" on="0"/>
+        <pt x="454" y="93" on="0"/>
+        <pt x="454" y="23" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="uni0066" xMin="-55" yMin="23" xMax="454" yMax="510">
+      <contour>
+        <pt x="-55" y="23" on="1"/>
+        <pt x="-55" y="92" on="0"/>
+        <pt x="-20" y="176" on="0"/>
+        <pt x="69" y="218" on="0"/>
+        <pt x="151" y="222" on="1"/>
+        <pt x="66" y="510" on="1"/>
+        <pt x="322" y="510" on="1"/>
+        <pt x="237" y="222" on="1"/>
+        <pt x="324" y="219" on="0"/>
+        <pt x="418" y="178" on="0"/>
+        <pt x="454" y="93" on="0"/>
+        <pt x="454" y="23" on="1"/>
+      </contour>
+      <contour>
+        <pt x="199" y="223" on="1"/>
+        <pt x="173" y="223" on="0"/>
+        <pt x="151" y="222" on="1"/>
+        <pt x="194" y="75" on="1"/>
+        <pt x="237" y="222" on="1"/>
+        <pt x="219" y="223" on="0"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="uni0067" xMin="66" yMin="0" xMax="322" yMax="510">
+      <component glyphName="uni0061" x="0" y="0" flags="0x204"/>
+    </TTGlyph>
+
+    <TTGlyph name="uni0068" xMin="100" yMin="-5" xMax="310" yMax="657">
+      <component glyphName="uni0064" x="60" y="460" flags="0x4"/>
+      <component glyphName="uni0062" x="0" y="0" flags="0x204"/>
+    </TTGlyph>
+
+    <TTGlyph name="uni0069" xMin="-55" yMin="-80" xMax="454" yMax="510">
+      <contour>
+        <pt x="-55" y="-80" on="1"/>
+        <pt x="-55" y="-20" on="0"/>
+        <pt x="-29" y="59" on="0"/>
+        <pt x="36" y="104" on="0"/>
+        <pt x="94" y="113" on="1"/>
+        <pt x="194" y="510" on="1"/>
+        <pt x="293" y="114" on="1"/>
+        <pt x="357" y="106" on="0"/>
+        <pt x="426" y="62" on="0"/>
+        <pt x="454" y="-19" on="0"/>
+        <pt x="454" y="-80" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="uni006A" xMin="-55" yMin="-280" xMax="454" yMax="230">
+      <contour>
+        <pt x="-55" y="-80" on="1"/>
+        <pt x="-55" y="-20" on="0"/>
+        <pt x="-29" y="59" on="0"/>
+        <pt x="36" y="104" on="0"/>
+        <pt x="95" y="113" on="1"/>
+        <pt x="66" y="230" on="1"/>
+        <pt x="322" y="230" on="1"/>
+        <pt x="293" y="114" on="1"/>
+        <pt x="356" y="106" on="0"/>
+        <pt x="426" y="62" on="0"/>
+        <pt x="454" y="-19" on="0"/>
+        <pt x="454" y="-80" on="1"/>
+        <pt x="244" y="-80" on="1"/>
+        <pt x="194" y="-280" on="1"/>
+        <pt x="144" y="-80" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="uni006B" xMin="66" yMin="0" xMax="422" yMax="510">
+      <component glyphName="uni0061" x="0" y="0" flags="0x4"/>
+      <component glyphName="uni0061" x="100" y="0" flags="0x4"/>
+    </TTGlyph>
+
+    <TTGlyph name="uni006C" xMin="78" yMin="0" xMax="422" yMax="510">
+      <component glyphName="uni0061" x="400" y="0" scalex="-1.0" scaley="1.0" flags="0x4"/>
+      <component glyphName="uni0061" x="100" y="0" flags="0x4"/>
+    </TTGlyph>
+
+  </glyf>
+
+  <name>
+    <namerecord nameID="3" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Unique Font Identifier
+    </namerecord>
+    <namerecord nameID="0" platformID="3" platEncID="1" langID="0x409">
+      Copyright © Some Foundry.
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      Some Font Regular (Style Map Family Name)
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      OpenType name Table Unique ID
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      Some Font (Preferred Family Name) Regular (Preferred Subfamily Name)
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      OpenType name Table Version
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      SomeFont-Regular Postscript Font Name
+    </namerecord>
+    <namerecord nameID="7" platformID="3" platEncID="1" langID="0x409">
+      Trademark Some Foundry
+    </namerecord>
+    <namerecord nameID="8" platformID="3" platEncID="1" langID="0x409">
+      Some Foundry (Manufacturer Name)
+    </namerecord>
+    <namerecord nameID="9" platformID="3" platEncID="1" langID="0x409">
+      Some Designer
+    </namerecord>
+    <namerecord nameID="10" platformID="3" platEncID="1" langID="0x409">
+      Some Font by Some Designer for Some Foundry.
+    </namerecord>
+    <namerecord nameID="11" platformID="3" platEncID="1" langID="0x409">
+      http://somefoundry.com
+    </namerecord>
+    <namerecord nameID="12" platformID="3" platEncID="1" langID="0x409">
+      http://somedesigner.com
+    </namerecord>
+    <namerecord nameID="13" platformID="3" platEncID="1" langID="0x409">
+      License info for Some Foundry.
+    </namerecord>
+    <namerecord nameID="14" platformID="3" platEncID="1" langID="0x409">
+      http://somefoundry.com/license
+    </namerecord>
+    <namerecord nameID="16" platformID="3" platEncID="1" langID="0x409">
+      Some Font (Preferred Family Name)
+    </namerecord>
+    <namerecord nameID="17" platformID="3" platEncID="1" langID="0x409">
+      Regular (Preferred Subfamily Name)
+    </namerecord>
+  </name>
+
+  <post>
+    <formatType value="2.0"/>
+    <italicAngle value="-12.5"/>
+    <underlinePosition value="-200"/>
+    <underlineThickness value="20"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+    <psNames>
+      <!-- This file uses unique glyph names based on the information
+           found in the 'post' table. Since these names might not be unique,
+           we have to invent artificial names in case of clashes. In order to
+           be able to retain the original information, we need a name to
+           ps name mapping for those cases where they differ. That's what
+           you see below.
+            -->
+    </psNames>
+    <extraNames>
+      <!-- following are the name that are not taken from the standard Mac glyph order -->
+      <psName name="uni0020"/>
+      <psName name="uni0061"/>
+      <psName name="uni0062"/>
+      <psName name="uni0063"/>
+      <psName name="uni0064"/>
+      <psName name="uni0065"/>
+      <psName name="uni0066"/>
+      <psName name="uni0067"/>
+      <psName name="uni0068"/>
+      <psName name="uni0069"/>
+      <psName name="uni006A"/>
+      <psName name="uni006B"/>
+      <psName name="uni006C"/>
+    </extraNames>
+  </post>
+
+  <gasp>
+    <gaspRange rangeMaxPPEM="7" rangeGaspBehavior="10"/>
+    <gaspRange rangeMaxPPEM="65535" rangeGaspBehavior="15"/>
+  </gasp>
+
+  <CUST raw="True">
+    <hexdata>
+      0001beef   
+    </hexdata>
+  </CUST>
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="kern"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="2"/>
+        <LookupFlag value="8"/>
+        <!-- SubTableCount=1 -->
+        <PairPos index="0" Format="1">
+          <Coverage Format="1">
+            <Glyph value="uni0061"/>
+            <Glyph value="uni0062"/>
+          </Coverage>
+          <ValueFormat1 value="4"/>
+          <ValueFormat2 value="0"/>
+          <!-- PairSetCount=2 -->
+          <PairSet index="0">
+            <!-- PairValueCount=3 -->
+            <PairValueRecord index="0">
+              <SecondGlyph value="uni0020"/>
+              <Value1 XAdvance="1"/>
+            </PairValueRecord>
+            <PairValueRecord index="1">
+              <SecondGlyph value="uni0061"/>
+              <Value1 XAdvance="5"/>
+            </PairValueRecord>
+            <PairValueRecord index="2">
+              <SecondGlyph value="uni0062"/>
+              <Value1 XAdvance="-10"/>
+            </PairValueRecord>
+          </PairSet>
+          <PairSet index="1">
+            <!-- PairValueCount=1 -->
+            <PairValueRecord index="0">
+              <SecondGlyph value="uni0061"/>
+              <Value1 XAdvance="-7"/>
+            </PairValueRecord>
+          </PairSet>
+        </PairPos>
+      </Lookup>
+    </LookupList>
+  </GPOS>
+
+</ttFont>

--- a/tests/data/TestFont.ttx
+++ b/tests/data/TestFont.ttx
@@ -9,6 +9,14 @@
     <GlyphID id="3" name="uni0062"/>
     <GlyphID id="4" name="uni0063"/>
     <GlyphID id="5" name="uni0064"/>
+    <GlyphID id="6" name="uni0065"/>
+    <GlyphID id="7" name="uni0066"/>
+    <GlyphID id="8" name="uni0067"/>
+    <GlyphID id="9" name="uni0068"/>
+    <GlyphID id="10" name="uni0069"/>
+    <GlyphID id="11" name="uni006A"/>
+    <GlyphID id="12" name="uni006B"/>
+    <GlyphID id="13" name="uni006C"/>
   </GlyphOrder>
 
   <head>
@@ -21,9 +29,9 @@
     <unitsPerEm value="1000"/>
     <created value="Fri Feb 17 17:17:17 2017"/>
     <modified value="Sun Feb 18 18:18:18 2018"/>
-    <xMin value="50"/>
-    <yMin value="-10"/>
-    <xMax value="450"/>
+    <xMin value="-55"/>
+    <yMin value="-280"/>
+    <xMax value="454"/>
     <yMax value="750"/>
     <macStyle value="00000000 00000000"/>
     <lowestRecPPEM value="10"/>
@@ -37,10 +45,10 @@
     <ascent value="750"/>
     <descent value="-250"/>
     <lineGap value="200"/>
-    <advanceWidthMax value="500"/>
-    <minLeftSideBearing value="50"/>
-    <minRightSideBearing value="50"/>
-    <xMaxExtent value="450"/>
+    <advanceWidthMax value="600"/>
+    <minLeftSideBearing value="-55"/>
+    <minRightSideBearing value="-66"/>
+    <xMaxExtent value="454"/>
     <caretSlopeRise value="1"/>
     <caretSlopeRun value="0"/>
     <caretOffset value="0"/>
@@ -49,17 +57,17 @@
     <reserved2 value="0"/>
     <reserved3 value="0"/>
     <metricDataFormat value="0"/>
-    <numberOfHMetrics value="5"/>
+    <numberOfHMetrics value="11"/>
   </hhea>
 
   <maxp>
     <!-- Most of this table will be recalculated by the compiler -->
     <tableVersion value="0x10000"/>
-    <numGlyphs value="6"/>
+    <numGlyphs value="14"/>
     <maxPoints value="12"/>
     <maxContours value="2"/>
-    <maxCompositePoints value="0"/>
-    <maxCompositeContours value="0"/>
+    <maxCompositePoints value="16"/>
+    <maxCompositeContours value="2"/>
     <maxZones value="1"/>
     <maxTwilightPoints value="0"/>
     <maxStorage value="0"/>
@@ -67,15 +75,15 @@
     <maxInstructionDefs value="0"/>
     <maxStackElements value="0"/>
     <maxSizeOfInstructions value="0"/>
-    <maxComponentElements value="0"/>
-    <maxComponentDepth value="0"/>
+    <maxComponentElements value="2"/>
+    <maxComponentDepth value="1"/>
   </maxp>
 
   <OS_2>
     <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
          will be recalculated by the compiler -->
     <version value="4"/>
-    <xAvgCharWidth value="383"/>
+    <xAvgCharWidth value="449"/>
     <usWeightClass value="500"/>
     <usWidthClass value="5"/>
     <fsType value="00000000 00000000"/>
@@ -109,7 +117,7 @@
     <achVendID value="SOME"/>
     <fsSelection value="00000000 01001000"/>
     <usFirstCharIndex value="32"/>
-    <usLastCharIndex value="100"/>
+    <usLastCharIndex value="108"/>
     <sTypoAscender value="750"/>
     <sTypoDescender value="-250"/>
     <sTypoLineGap value="200"/>
@@ -131,6 +139,14 @@
     <mtx name="uni0062" width="410" lsb="100"/>
     <mtx name="uni0063" width="374" lsb="100"/>
     <mtx name="uni0064" width="374" lsb="90"/>
+    <mtx name="uni0065" width="388" lsb="-55"/>
+    <mtx name="uni0066" width="410" lsb="-55"/>
+    <mtx name="uni0067" width="388" lsb="66"/>
+    <mtx name="uni0068" width="410" lsb="100"/>
+    <mtx name="uni0069" width="600" lsb="-55"/>
+    <mtx name="uni006A" width="600" lsb="-55"/>
+    <mtx name="uni006B" width="600" lsb="66"/>
+    <mtx name="uni006C" width="600" lsb="78"/>
   </hmtx>
 
   <cmap>
@@ -141,6 +157,14 @@
       <map code="0x62" name="uni0062"/><!-- LATIN SMALL LETTER B -->
       <map code="0x63" name="uni0063"/><!-- LATIN SMALL LETTER C -->
       <map code="0x64" name="uni0064"/><!-- LATIN SMALL LETTER D -->
+      <map code="0x65" name="uni0065"/><!-- LATIN SMALL LETTER E -->
+      <map code="0x66" name="uni0066"/><!-- LATIN SMALL LETTER F -->
+      <map code="0x67" name="uni0067"/><!-- LATIN SMALL LETTER G -->
+      <map code="0x68" name="uni0068"/><!-- LATIN SMALL LETTER H -->
+      <map code="0x69" name="uni0069"/><!-- LATIN SMALL LETTER I -->
+      <map code="0x6a" name="uni006A"/><!-- LATIN SMALL LETTER J -->
+      <map code="0x6b" name="uni006B"/><!-- LATIN SMALL LETTER K -->
+      <map code="0x6c" name="uni006C"/><!-- LATIN SMALL LETTER L -->
     </cmap_format_4>
     <cmap_format_4 platformID="3" platEncID="1" language="0">
       <map code="0x20" name="uni0020"/><!-- SPACE -->
@@ -148,6 +172,14 @@
       <map code="0x62" name="uni0062"/><!-- LATIN SMALL LETTER B -->
       <map code="0x63" name="uni0063"/><!-- LATIN SMALL LETTER C -->
       <map code="0x64" name="uni0064"/><!-- LATIN SMALL LETTER D -->
+      <map code="0x65" name="uni0065"/><!-- LATIN SMALL LETTER E -->
+      <map code="0x66" name="uni0066"/><!-- LATIN SMALL LETTER F -->
+      <map code="0x67" name="uni0067"/><!-- LATIN SMALL LETTER G -->
+      <map code="0x68" name="uni0068"/><!-- LATIN SMALL LETTER H -->
+      <map code="0x69" name="uni0069"/><!-- LATIN SMALL LETTER I -->
+      <map code="0x6a" name="uni006A"/><!-- LATIN SMALL LETTER J -->
+      <map code="0x6b" name="uni006B"/><!-- LATIN SMALL LETTER K -->
+      <map code="0x6c" name="uni006C"/><!-- LATIN SMALL LETTER L -->
     </cmap_format_4>
   </cmap>
 
@@ -181,8 +213,8 @@
     <TTGlyph name="uni0061" xMin="66" yMin="0" xMax="322" yMax="510">
       <contour>
         <pt x="66" y="0" on="1"/>
-        <pt x="322" y="0" on="1"/>
         <pt x="194" y="510" on="1"/>
+        <pt x="322" y="0" on="1"/>
       </contour>
       <instructions/>
     </TTGlyph>
@@ -190,9 +222,9 @@
     <TTGlyph name="uni0062" xMin="100" yMin="-5" xMax="310" yMax="505">
       <contour>
         <pt x="100" y="505" on="1"/>
-        <pt x="100" y="-5" on="1"/>
-        <pt x="310" y="-5" on="1"/>
         <pt x="310" y="505" on="1"/>
+        <pt x="310" y="-5" on="1"/>
+        <pt x="100" y="-5" on="1"/>
       </contour>
       <instructions/>
     </TTGlyph>
@@ -200,14 +232,14 @@
     <TTGlyph name="uni0063" xMin="100" yMin="-10" xMax="300" yMax="500">
       <contour>
         <pt x="300" y="-10" on="1"/>
-        <pt x="300" y="500" on="1"/>
-        <pt x="225" y="500" on="0"/>
-        <pt x="138" y="458" on="0"/>
-        <pt x="100" y="348" on="0"/>
-        <pt x="100" y="245" on="1"/>
-        <pt x="100" y="142" on="0"/>
-        <pt x="138" y="32" on="0"/>
         <pt x="225" y="-10" on="0"/>
+        <pt x="138" y="32" on="0"/>
+        <pt x="100" y="142" on="0"/>
+        <pt x="100" y="245" on="1"/>
+        <pt x="100" y="348" on="0"/>
+        <pt x="138" y="458" on="0"/>
+        <pt x="225" y="500" on="0"/>
+        <pt x="300" y="500" on="1"/>
       </contour>
       <instructions/>
     </TTGlyph>
@@ -228,6 +260,105 @@
         <pt x="125" y="197" on="0"/>
       </contour>
       <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="uni0065" xMin="-55" yMin="23" xMax="454" yMax="510">
+      <contour>
+        <pt x="66" y="510" on="1"/>
+        <pt x="322" y="510" on="1"/>
+        <pt x="194" y="75" on="1"/>
+      </contour>
+      <contour>
+        <pt x="-55" y="23" on="1"/>
+        <pt x="-55" y="98" on="0"/>
+        <pt x="-13" y="185" on="0"/>
+        <pt x="97" y="223" on="0"/>
+        <pt x="199" y="223" on="1"/>
+        <pt x="302" y="223" on="0"/>
+        <pt x="412" y="185" on="0"/>
+        <pt x="454" y="98" on="0"/>
+        <pt x="454" y="23" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="uni0066" xMin="-55" yMin="23" xMax="454" yMax="510">
+      <contour>
+        <pt x="66" y="510" on="1"/>
+        <pt x="194" y="75" on="1"/>
+        <pt x="322" y="510" on="1"/>
+      </contour>
+      <contour>
+        <pt x="-55" y="23" on="1"/>
+        <pt x="-55" y="98" on="0"/>
+        <pt x="-13" y="185" on="0"/>
+        <pt x="97" y="223" on="0"/>
+        <pt x="199" y="223" on="1"/>
+        <pt x="302" y="223" on="0"/>
+        <pt x="412" y="185" on="0"/>
+        <pt x="454" y="98" on="0"/>
+        <pt x="454" y="23" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="uni0067" xMin="66" yMin="0" xMax="322" yMax="510">
+      <component glyphName="uni0061" x="0" y="0" flags="0x204"/>
+    </TTGlyph>
+
+    <TTGlyph name="uni0068" xMin="100" yMin="-5" xMax="310" yMax="657">
+      <component glyphName="uni0064" x="60" y="460" flags="0x4"/>
+      <component glyphName="uni0062" x="0" y="0" flags="0x204"/>
+    </TTGlyph>
+
+    <TTGlyph name="uni0069" xMin="-55" yMin="-80" xMax="454" yMax="510">
+      <contour>
+        <pt x="-55" y="-80" on="1"/>
+        <pt x="-55" y="-6" on="0"/>
+        <pt x="-13" y="82" on="0"/>
+        <pt x="97" y="119" on="0"/>
+        <pt x="199" y="119" on="1"/>
+        <pt x="302" y="119" on="0"/>
+        <pt x="412" y="82" on="0"/>
+        <pt x="454" y="-6" on="0"/>
+        <pt x="454" y="-80" on="1"/>
+      </contour>
+      <contour>
+        <pt x="66" y="0" on="1"/>
+        <pt x="194" y="510" on="1"/>
+        <pt x="322" y="0" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="uni006A" xMin="-55" yMin="-280" xMax="454" yMax="230">
+      <contour>
+        <pt x="-55" y="-80" on="1"/>
+        <pt x="-55" y="-6" on="0"/>
+        <pt x="-13" y="82" on="0"/>
+        <pt x="97" y="119" on="0"/>
+        <pt x="199" y="119" on="1"/>
+        <pt x="302" y="119" on="0"/>
+        <pt x="412" y="82" on="0"/>
+        <pt x="454" y="-6" on="0"/>
+        <pt x="454" y="-80" on="1"/>
+      </contour>
+      <contour>
+        <pt x="66" y="230" on="1"/>
+        <pt x="322" y="230" on="1"/>
+        <pt x="194" y="-280" on="1"/>
+      </contour>
+      <instructions/>
+    </TTGlyph>
+
+    <TTGlyph name="uni006B" xMin="66" yMin="0" xMax="422" yMax="510">
+      <component glyphName="uni0061" x="0" y="0" flags="0x4"/>
+      <component glyphName="uni0061" x="100" y="0" flags="0x4"/>
+    </TTGlyph>
+
+    <TTGlyph name="uni006C" xMin="78" yMin="0" xMax="422" yMax="510">
+      <component glyphName="uni0061" x="400" y="0" scalex="-1.0" scaley="1.0" flags="0x4"/>
+      <component glyphName="uni0061" x="100" y="0" flags="0x4"/>
     </TTGlyph>
 
   </glyf>
@@ -310,6 +441,19 @@
     </psNames>
     <extraNames>
       <!-- following are the name that are not taken from the standard Mac glyph order -->
+      <psName name="uni0020"/>
+      <psName name="uni0061"/>
+      <psName name="uni0062"/>
+      <psName name="uni0063"/>
+      <psName name="uni0064"/>
+      <psName name="uni0065"/>
+      <psName name="uni0066"/>
+      <psName name="uni0067"/>
+      <psName name="uni0068"/>
+      <psName name="uni0069"/>
+      <psName name="uni006A"/>
+      <psName name="uni006B"/>
+      <psName name="uni006C"/>
     </extraNames>
   </post>
 
@@ -320,7 +464,7 @@
 
   <CUST raw="True">
     <hexdata>
-      0001beef
+      0001beef   
     </hexdata>
   </CUST>
 

--- a/tests/data/TestFont.ufo/glyphs/a.glif
+++ b/tests/data/TestFont.ufo/glyphs/a.glif
@@ -5,8 +5,8 @@
 	<outline>
 		<contour>
 			<point x="66" y="0" type="line"/>
-			<point x="194" y="510" type="line"/>
 			<point x="322" y="0" type="line"/>
+			<point x="194" y="510" type="line"/>
 		</contour>
 	</outline>
 </glyph>

--- a/tests/data/TestFont.ufo/glyphs/b.glif
+++ b/tests/data/TestFont.ufo/glyphs/b.glif
@@ -5,9 +5,9 @@
 	<outline>
 		<contour>
 			<point x="100" y="505" type="line"/>
-			<point x="310" y="505" type="line"/>
-			<point x="310" y="-5" type="line"/>
 			<point x="100" y="-5" type="line"/>
+			<point x="310" y="-5" type="line"/>
+			<point x="310" y="505" type="line"/>
 		</contour>
 	</outline>
 </glyph>

--- a/tests/data/TestFont.ufo/glyphs/c.glif
+++ b/tests/data/TestFont.ufo/glyphs/c.glif
@@ -4,13 +4,13 @@
 	<advance width="374"/>
 	<outline>
 		<contour>
-			<point x="300" y="-10" type="line"/>
-			<point x="150" y="-10"/>
-			<point x="100" y="40"/>
-			<point x="100" y="245" type="curve"/>
-			<point x="100" y="450"/>
+			<point x="300" y="-10" type="curve"/>
+			<point x="300" y="500" type="line"/>
 			<point x="150" y="500"/>
-			<point x="300" y="500" type="curve"/>
+			<point x="100" y="450"/>
+			<point x="100" y="245" type="curve"/>
+			<point x="100" y="40"/>
+			<point x="150" y="-10"/>
 		</contour>
 	</outline>
 </glyph>

--- a/tests/data/TestFont.ufo/glyphs/contents.plist
+++ b/tests/data/TestFont.ufo/glyphs/contents.plist
@@ -12,6 +12,22 @@
 		<string>c.glif</string>
 		<key>d</key>
 		<string>d.glif</string>
+		<key>e</key>
+		<string>e.glif</string>
+		<key>f</key>
+		<string>f.glif</string>
+		<key>g</key>
+		<string>g.glif</string>
+		<key>h</key>
+		<string>h.glif</string>
+		<key>i</key>
+		<string>i.glif</string>
+		<key>j</key>
+		<string>j.glif</string>
+		<key>k</key>
+		<string>k.glif</string>
+		<key>l</key>
+		<string>l.glif</string>
 		<key>space</key>
 		<string>space.glif</string>
 	</dict>

--- a/tests/data/TestFont.ufo/glyphs/d.glif
+++ b/tests/data/TestFont.ufo/glyphs/d.glif
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="d" format="2">
-  <advance width="374"/>
-  <unicode hex="0064"/>
-  <outline>
-    <contour>
-      <point x="150.66" y="197.32" type="curve"/>
-      <point x="117" y="197.32"/>
-      <point x="90.33" y="170.33"/>
-      <point x="90.33" y="137" type="curve"/>
-      <point x="90.33" y="103.67"/>
-      <point x="117" y="77.01"/>
-      <point x="150.66" y="77.01" type="curve"/>
-      <point x="183.99" y="77.01"/>
-      <point x="210.65" y="103.67"/>
-      <point x="210.65" y="137" type="curve"/>
-      <point x="210.65" y="170.33"/>
-      <point x="183.99" y="197.32"/>
-    </contour>
-  </outline>
+	<unicode hex="0064"/>
+	<advance width="374"/>
+	<outline>
+		<contour>
+			<point x="150.66" y="197.32" type="curve"/>
+			<point x="117" y="197.32"/>
+			<point x="90.33" y="170.33"/>
+			<point x="90.33" y="137" type="curve"/>
+			<point x="90.33" y="103.67"/>
+			<point x="117" y="77.01"/>
+			<point x="150.66" y="77.01" type="curve"/>
+			<point x="183.99" y="77.01"/>
+			<point x="210.65" y="103.67"/>
+			<point x="210.65" y="137" type="curve"/>
+			<point x="210.65" y="170.33"/>
+			<point x="183.99" y="197.32"/>
+		</contour>
+	</outline>
 </glyph>

--- a/tests/data/TestFont.ufo/glyphs/e.glif
+++ b/tests/data/TestFont.ufo/glyphs/e.glif
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="e" format="2">
+	<unicode hex="0065"/>
+	<advance width="388"/>
+	<outline>
+		<contour>
+			<point x="66" y="510" type="line"/>
+			<point x="194" y="75" type="line"/>
+			<point x="322" y="510" type="line"/>
+		</contour>
+		<contour>
+			<point x="-55" y="23" type="curve"/>
+			<point x="454" y="23" type="line"/>
+			<point x="454" y="173"/>
+			<point x="404" y="223"/>
+			<point x="199" y="223" type="curve"/>
+			<point x="-5" y="223"/>
+			<point x="-55" y="173"/>
+		</contour>
+	</outline>
+</glyph>

--- a/tests/data/TestFont.ufo/glyphs/f.glif
+++ b/tests/data/TestFont.ufo/glyphs/f.glif
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="f" format="2">
+	<unicode hex="0066"/>
+	<advance width="410"/>
+	<outline>
+		<contour>
+			<point x="66" y="510" type="line"/>
+			<point x="322" y="510" type="line"/>
+			<point x="194" y="75" type="line"/>
+		</contour>
+		<contour>
+			<point x="-55" y="23" type="curve"/>
+			<point x="454" y="23" type="line"/>
+			<point x="454" y="173"/>
+			<point x="404" y="223"/>
+			<point x="199" y="223" type="curve"/>
+			<point x="-5" y="223"/>
+			<point x="-55" y="173"/>
+		</contour>
+	</outline>
+</glyph>

--- a/tests/data/TestFont.ufo/glyphs/g.glif
+++ b/tests/data/TestFont.ufo/glyphs/g.glif
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="g" format="2">
+	<unicode hex="0067"/>
+	<advance width="388"/>
+	<outline>
+		<component base="a"/>
+	</outline>
+</glyph>

--- a/tests/data/TestFont.ufo/glyphs/h.glif
+++ b/tests/data/TestFont.ufo/glyphs/h.glif
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="h" format="2">
+	<unicode hex="0068"/>
+	<advance width="410"/>
+	<outline>
+		<component base="d" xOffset="60" yOffset="460"/>
+		<component base="b"/>
+	</outline>
+</glyph>

--- a/tests/data/TestFont.ufo/glyphs/i.glif
+++ b/tests/data/TestFont.ufo/glyphs/i.glif
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="i" format="2">
+	<unicode hex="0069"/>
+	<advance width="600"/>
+	<outline>
+		<contour>
+			<point x="-55" y="-80" type="curve"/>
+			<point x="454" y="-80" type="line"/>
+			<point x="454" y="69"/>
+			<point x="404" y="119"/>
+			<point x="199" y="119" type="curve"/>
+			<point x="-5" y="119"/>
+			<point x="-55" y="69"/>
+		</contour>
+		<component base="a"/>
+	</outline>
+</glyph>

--- a/tests/data/TestFont.ufo/glyphs/j.glif
+++ b/tests/data/TestFont.ufo/glyphs/j.glif
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="j" format="2">
+	<unicode hex="006A"/>
+	<advance width="600"/>
+	<outline>
+		<contour>
+			<point x="-55" y="-80" type="curve"/>
+			<point x="454" y="-80" type="line"/>
+			<point x="454" y="69"/>
+			<point x="404" y="119"/>
+			<point x="199" y="119" type="curve"/>
+			<point x="-5" y="119"/>
+			<point x="-55" y="69"/>
+		</contour>
+		<component base="a" yScale="-1" yOffset="230"/>
+	</outline>
+</glyph>

--- a/tests/data/TestFont.ufo/glyphs/k.glif
+++ b/tests/data/TestFont.ufo/glyphs/k.glif
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="k" format="2">
+	<unicode hex="006B"/>
+	<advance width="600"/>
+	<outline>
+		<component base="a"/>
+		<component base="a" xOffset="100"/>
+	</outline>
+</glyph>

--- a/tests/data/TestFont.ufo/glyphs/l.glif
+++ b/tests/data/TestFont.ufo/glyphs/l.glif
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="l" format="2">
+	<unicode hex="006C"/>
+	<advance width="600"/>
+	<outline>
+		<component base="a" xScale="-1" xOffset="400"/>
+		<component base="a" xOffset="100"/>
+	</outline>
+</glyph>

--- a/tests/data/TestFont.ufo/groups.plist
+++ b/tests/data/TestFont.ufo/groups.plist
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-	<dict>
-	</dict>
-</plist>

--- a/tests/data/TestFont.ufo/kerning.plist
+++ b/tests/data/TestFont.ufo/kerning.plist
@@ -4,12 +4,12 @@
 	<dict>
 		<key>a</key>
 		<dict>
-			<key>space</key>
-			<integer>1</integer>
 			<key>a</key>
 			<integer>5</integer>
 			<key>b</key>
 			<integer>-10</integer>
+			<key>space</key>
+			<integer>1</integer>
 		</dict>
 		<key>b</key>
 		<dict>

--- a/tests/data/TestFont.ufo/lib.plist
+++ b/tests/data/TestFont.ufo/lib.plist
@@ -12,6 +12,14 @@
 			<string>b</string>
 			<string>c</string>
 			<string>d</string>
+			<string>e</string>
+			<string>f</string>
+			<string>g</string>
+			<string>h</string>
+			<string>i</string>
+			<string>j</string>
+			<string>k</string>
+			<string>l</string>
 		</array>
 	</dict>
 </plist>

--- a/tests/data/TestFont.ufo/lib.plist
+++ b/tests/data/TestFont.ufo/lib.plist
@@ -11,6 +11,7 @@
 			<string>a</string>
 			<string>b</string>
 			<string>c</string>
+			<string>d</string>
 		</array>
 	</dict>
 </plist>

--- a/tests/outlineCompiler_test.py
+++ b/tests/outlineCompiler_test.py
@@ -272,13 +272,15 @@ class TestGlyphOrder(unittest.TestCase):
         self.ufo = getTestUFO()
 
     def test_compile_original_glyph_order(self):
-        DEFAULT_ORDER = ['.notdef', 'space', 'a', 'b', 'c', 'd']
+        DEFAULT_ORDER = ['.notdef', 'space', 'a', 'b', 'c', 'd',
+                         'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l']
         compiler = OutlineTTFCompiler(self.ufo)
         compiler.compile()
         self.assertEqual(compiler.otf.getGlyphOrder(), DEFAULT_ORDER)
 
     def test_compile_tweaked_glyph_order(self):
-        NEW_ORDER = ['.notdef', 'space', 'b', 'a', 'c', 'd']
+        NEW_ORDER = ['.notdef', 'space', 'b', 'a', 'c', 'd',
+                     'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l']
         self.ufo.lib['public.glyphOrder'] = NEW_ORDER
         compiler = OutlineTTFCompiler(self.ufo)
         compiler.compile()
@@ -289,7 +291,8 @@ class TestGlyphOrder(unittest.TestCase):
         ufo2ft always puts .notdef first.
         """
         NEW_ORDER = ['b', 'a', 'c', 'd', 'space', '.notdef']
-        EXPECTED_ORDER = ['.notdef', 'b', 'a', 'c', 'd', 'space']
+        EXPECTED_ORDER = ['.notdef', 'b', 'a', 'c', 'd', 'space',
+                          'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l']
         self.ufo.lib['public.glyphOrder'] = NEW_ORDER
         compiler = OutlineTTFCompiler(self.ufo)
         compiler.compile()
@@ -304,13 +307,17 @@ class TestNames(unittest.TestCase):
     def test_compile_without_production_names(self):
         result = compileTTF(self.ufo, useProductionNames=False)
         self.assertEqual(result.getGlyphOrder(),
-                         ['.notdef', 'space', 'a', 'b', 'c', 'd'])
+                         ['.notdef', 'space', 'a', 'b', 'c', 'd',
+                          'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l'])
 
     def test_compile_with_production_names(self):
         result = compileTTF(self.ufo, useProductionNames=True)
         self.assertEqual(result.getGlyphOrder(),
                          ['.notdef', 'uni0020', 'uni0061', 'uni0062',
-                          'uni0063', 'uni0064'])
+                          'uni0063', 'uni0064', 'uni0065', 'uni0066',
+                          'uni0067', 'uni0068', 'uni0069', 'uni006A',
+                          'uni006B', 'uni006C',
+                         ])
 
     CUSTOM_POSTSCRIPT_NAMES = {
             '.notdef': '.notdef',
@@ -318,7 +325,15 @@ class TestNames(unittest.TestCase):
             'a': 'bar',
             'b': 'baz',
             'c': 'meh',
-            'd': 'doh'
+            'd': 'doh',
+            'e': 'bim',
+            'f': 'bum',
+            'g': 'bam',
+            'h': 'bib',
+            'i': 'bob',
+            'j': 'bub',
+            'k': 'kkk',
+            'l': 'lll',
         }
 
     def test_compile_with_custom_postscript_names(self):
@@ -333,7 +348,9 @@ class TestNames(unittest.TestCase):
         self.ufo.lib['public.postscriptNames'] = custom_names
         result = compileTTF(self.ufo, useProductionNames=True)
         self.assertEqual(result.getGlyphOrder(),
-                         ['.notdef', 'foo', 'bar', 'baz', 'meh', 'doh'])
+                         ['.notdef', 'foo', 'bar', 'baz', 'meh', 'doh',
+                          'bim', 'bum', 'bam', 'bib', 'bob', 'bub',
+                          'kkk', 'lll'])
 
 
 if __name__ == "__main__":

--- a/tests/outlineCompiler_test.py
+++ b/tests/outlineCompiler_test.py
@@ -83,6 +83,14 @@ class OutlineTTFCompilerTest(unittest.TestCase):
         ttf = compiler.compile()
         self.assertFalse(ttf['glyf']['Iacute'].components[1].flags & USE_MY_METRICS)
 
+    def test_importTTX(self):
+        compiler = OutlineTTFCompiler(self.ufo)
+        otf = compiler.otf = TTFont()
+        compiler.importTTX()
+        self.assertIn("CUST", otf)
+        self.assertEqual(otf["CUST"].data, b"\x00\x01\xbe\xef")
+        self.assertEqual(otf.sfntVersion, "\x00\x01\x00\x00")
+
 
 class OutlineOTFCompilerTest(unittest.TestCase):
 
@@ -249,6 +257,13 @@ class OutlineOTFCompilerTest(unittest.TestCase):
         self.assertEqual(compiler.glyphBoundingBoxes['d'],
                          (90, 77, 211, 198))
 
+    def test_importTTX(self):
+        compiler = OutlineOTFCompiler(self.ufo)
+        otf = compiler.otf = TTFont(sfntVersion="OTTO")
+        compiler.importTTX()
+        self.assertIn("CUST", otf)
+        self.assertEqual(otf["CUST"].data, b"\x00\x01\xbe\xef")
+        self.assertEqual(otf.sfntVersion, "OTTO")
 
 
 class TestGlyphOrder(unittest.TestCase):

--- a/tests/outlineCompiler_test.py
+++ b/tests/outlineCompiler_test.py
@@ -58,25 +58,22 @@ class OutlineTTFCompilerTest(unittest.TestCase):
                          (90, 77, 211, 197))
 
     def test_autoUseMyMetrics(self):
-        # make sure we get the same USE_MY_METRICS flags with both values of
-        # 'convertCubics': https://github.com/googlei18n/ufo2ft/issues/136
         ufo = getTestUFO('UseMyMetrics')
-        for convertCubics in (False, True):
-            compiler = OutlineTTFCompiler(ufo, convertCubics=convertCubics)
-            ttf = compiler.compile()
-            # the first component in the 'Iacute' composite glyph ('acute')
-            # does _not_ have the USE_MY_METRICS flag
-            self.assertFalse(
-                ttf['glyf']['Iacute'].components[0].flags & USE_MY_METRICS)
-            # the second component in the 'Iacute' composite glyph ('I')
-            # has the USE_MY_METRICS flag set
-            self.assertTrue(
-                ttf['glyf']['Iacute'].components[1].flags & USE_MY_METRICS)
-            # none of the 'I' components of the 'romanthree' glyph has
-            # the USE_MY_METRICS flag set, because the composite glyph has a
-            # different width
-            for component in ttf['glyf']['romanthree'].components:
-                self.assertFalse(component.flags & USE_MY_METRICS)
+        compiler = OutlineTTFCompiler(ufo)
+        ttf = compiler.compile()
+        # the first component in the 'Iacute' composite glyph ('acute')
+        # does _not_ have the USE_MY_METRICS flag
+        self.assertFalse(
+            ttf['glyf']['Iacute'].components[0].flags & USE_MY_METRICS)
+        # the second component in the 'Iacute' composite glyph ('I')
+        # has the USE_MY_METRICS flag set
+        self.assertTrue(
+            ttf['glyf']['Iacute'].components[1].flags & USE_MY_METRICS)
+        # none of the 'I' components of the 'romanthree' glyph has
+        # the USE_MY_METRICS flag set, because the composite glyph has a
+        # different width
+        for component in ttf['glyf']['romanthree'].components:
+            self.assertFalse(component.flags & USE_MY_METRICS)
 
     def test_autoUseMyMetrics_None(self):
         ufo = getTestUFO('UseMyMetrics')

--- a/tox.ini
+++ b/tox.ini
@@ -22,3 +22,14 @@ skip_install = true
 commands =
     coverage combine
     coverage html
+
+[testenv:codecov]
+passenv = *
+deps =
+    coverage
+    codecov
+skip_install = true
+ignore_outcome = true
+commands =
+    coverage combine
+    codecov --env TOXENV

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,24 @@
 [tox]
-envlist = py27, py36
+envlist = py{27,36}-cov, htmlcov
 
 [testenv]
 deps =
+    cov: coverage
     pytest
     -rrequirements.txt
 commands =
-    py.test {posargs}
+    # run the test suite against the package installed inside tox env.
+    # We use parallel mode and then combine later so that coverage.py will take
+    # paths like .tox/py36/lib/python3.6/site-packages/fontTools and collapse
+    # them into Lib/fontTools.
+    cov: coverage run --parallel-mode -m pytest {posargs}
+    nocov: pytest {posargs}
+
+[testenv:htmlcov]
+basepython = python3.6
+deps =
+    coverage
+skip_install = true
+commands =
+    coverage combine
+    coverage html


### PR DESCRIPTION
Towards addressing https://github.com/googlei18n/ufo2ft/issues/120

Composite glyph decomposition, overlap removal (via booleanOperations) and cubic to quadratic conversion are now handled as "filters" in the same way as custom user-defined filters.

Fixes https://github.com/googlei18n/ufo2ft/issues/166

Please read commit messages for more info.

It'd be nice if those who use or have used ufo2ft directly, without fontmake, could take a look.
Thanks