### PR TITLE
Add fallback for hhea caretSlopeRise and caretSlopeRun to match makeotf

### DIFF
--- a/Lib/ufo2ft/fontInfoData.py
+++ b/Lib/ufo2ft/fontInfoData.py
@@ -14,6 +14,7 @@ used externally as well.
 from __future__ import print_function, division, absolute_import, unicode_literals
 
 import logging
+import math
 import time
 import unicodedata
 
@@ -71,6 +72,26 @@ def openTypeHheaDescenderFallback(info):
     Fallback to *descender*.
     """
     return info.descender
+
+def openTypeHheaCaretSlopeRiseFallback(info):
+    """
+    Fallback to *caretSlopeRise*.
+    """
+    italicAngle = postscriptSlantAngleFallback(info)
+    if italicAngle:
+        return 1000
+    return 1
+
+def openTypeHheaCaretSlopeRunFallback(info):
+    """
+    Fallback to *caretSlopeRun*.
+    """
+    f = lambda a, b: int((math.tan(math.radians(-a)) * 1000) + b)
+    italicAngle = postscriptSlantAngleFallback(info)
+    if italicAngle:
+        b = 0.5 if italicAngle < 0 else -0.5
+        return f(italicAngle, b)
+    return 0
 
 # name
 
@@ -291,8 +312,6 @@ staticFallbackData = dict(
     openTypeHeadFlags=[0, 1],
 
     openTypeHheaLineGap=0,
-    openTypeHheaCaretSlopeRise=1,
-    openTypeHheaCaretSlopeRun=0,
     openTypeHheaCaretOffset=0,
 
     openTypeNameDesigner=None,
@@ -364,6 +383,8 @@ specialFallbacks = dict(
     openTypeHeadCreated=openTypeHeadCreatedFallback,
     openTypeHheaAscender=openTypeHheaAscenderFallback,
     openTypeHheaDescender=openTypeHheaDescenderFallback,
+    openTypeHheaCaretSlopeRise=openTypeHheaCaretSlopeRiseFallback,
+    openTypeHheaCaretSlopeRun=openTypeHheaCaretSlopeRunFallback,
     openTypeNameVersion=openTypeNameVersionFallback,
     openTypeNameUniqueID=openTypeNameUniqueIDFallback,
     openTypeNamePreferredFamilyName=openTypeNamePreferredFamilyNameFallback,

--- a/tests/fontInfoData_test.py
+++ b/tests/fontInfoData_test.py
@@ -69,6 +69,26 @@ class GetAttrWithFallbackTest(unittest.TestCase):
         self.assertEqual(
             getAttrWithFallback(info, "openTypeOS2WinDescent"), 250)
 
+    def test_caret_slope(self):
+        info = TestInfoObject()
+
+        self.assertEqual(
+            getAttrWithFallback(info, "openTypeHheaCaretSlopeRise"), 1)
+        self.assertEqual(
+            getAttrWithFallback(info, "openTypeHheaCaretSlopeRun"), 0)
+
+        info.italicAngle = -12
+        self.assertEqual(
+            getAttrWithFallback(info, "openTypeHheaCaretSlopeRise"), 1000)
+        self.assertEqual(
+            getAttrWithFallback(info, "openTypeHheaCaretSlopeRun"), 213)
+
+        info.italicAngle = 12
+        self.assertEqual(
+            getAttrWithFallback(info, "openTypeHheaCaretSlopeRise"), 1000)
+        self.assertEqual(
+            getAttrWithFallback(info, "openTypeHheaCaretSlopeRun"), -213)
+
 
 class PostscriptBlueScaleFallbackTest(unittest.TestCase):
 
@@ -102,7 +122,9 @@ class TestInfoObject(object):
         self.xHeight = 450
         self.capHeight = 600
         self.ascender = 650
-
+        self.italicAngle = 0
+        self.openTypeHheaCaretSlopeRiseFallback = None
+        self.openTypeHheaCaretSlopeRunFallback = None
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
From https://github.com/googlei18n/glyphsLib/pull/284, but do it here instead because we want to match what makeotf does, not Glyphs itself. 