### PR TITLE
add support for Transformations filter

### DIFF
--- a/Lib/ufo2ft/filters/__init__.py
+++ b/Lib/ufo2ft/filters/__init__.py
@@ -198,6 +198,9 @@ class BaseFilter(object):
                 if include(glyph) and filter_(glyph):
                     modified.add(glyphName)
 
-        logger.debug("Took %.3fs to run %s on %d glyphs",
-                     t, self.name, len(modified))
+        num = len(modified)
+        if num > 0:
+            logger.debug("Took %.3fs to run %s on %d glyph%s",
+                         t, self.name, len(modified),
+                         "" if num == 1 else "s")
         return modified

--- a/Lib/ufo2ft/filters/__init__.py
+++ b/Lib/ufo2ft/filters/__init__.py
@@ -149,18 +149,19 @@ class BaseFilter(object):
         pass
 
     def set_context(self, font, glyphSet):
-        """ Return a dictionary that will be used to populate a `self.context`
-        namespace, which is reset before each new filter call.
+        """ Populate a `self.context` namespace, which is reset before each
+        new filter call.
 
         Subclasses can override this to provide contextual information
         which depends on other data in the font that is not available in
         the glyphs objects currently being filtered, or set any other
         temporary attributes.
 
-        The default implementation simply return the current font and glyphSet
-        as the context.
+        The default implementation simply sets the current font and glyphSet,
+        and returns the namespace instance.
         """
-        return dict(font=font, glyphSet=glyphSet)
+        self.context = SimpleNamespace(font=font, glyphSet=glyphSet)
+        return self.context
 
     def filter(self, glyph):
         """ This is where the filter is applied to a single glyph.
@@ -185,7 +186,7 @@ class BaseFilter(object):
         if glyphSet is None:
             glyphSet = font
 
-        self.context = SimpleNamespace(**self.set_context(font, glyphSet))
+        self.set_context(font, glyphSet)
 
         filter_ = self.filter
         include = self.include

--- a/Lib/ufo2ft/filters/cubicToQuadratic.py
+++ b/Lib/ufo2ft/filters/cubicToQuadratic.py
@@ -19,9 +19,14 @@ class CubicToQuadraticFilter(BaseFilter):
     }
 
     def set_context(self, font, glyphSet):
+        ctx = super(CubicToQuadraticFilter, self).set_context(font, glyphSet)
+
         relativeError = self.options.conversionError or DEFAULT_MAX_ERR
-        absoluteError = relativeError * font.info.unitsPerEm
-        return dict(absoluteError=absoluteError, stats=dict())
+        ctx.absoluteError = relativeError * font.info.unitsPerEm
+
+        ctx.stats = {}
+
+        return ctx
 
     def __call__(self, font, glyphSet=None):
         if super(CubicToQuadraticFilter, self).__call__(font, glyphSet):

--- a/Lib/ufo2ft/filters/transformations.py
+++ b/Lib/ufo2ft/filters/transformations.py
@@ -50,23 +50,23 @@ class TransformationsFilter(BaseFilter):
             raise ValueError("%r is not a valid Origin value"
                              % self.options.Origin)
 
-    def set_context(self, font, glyphSet):
-        ctx = super(TransformationsFilter, self).set_context(font, glyphSet)
-
-        origin = self.options.Origin
+    def get_origin_height(self, font, origin):
         if origin is self.Origin.BASELINE:
-            ctx.origin_height = 0
+            return 0
         elif origin is self.Origin.CAP_HEIGHT:
-            ctx.origin_height = font.info.capHeight
+            return font.info.capHeight
         elif origin is self.Origin.HALF_CAP_HEIGHT:
-            ctx.origin_height = round(font.info.capHeight/2)
+            return round(font.info.capHeight/2)
         elif origin is self.Origin.X_HEIGHT:
-            ctx.origin_height = font.info.xHeight
+            return font.info.xHeight
         elif origin is self.Origin.HALF_X_HEIGHT:
-            ctx.origin_height = round(font.info.xHeight/2)
+            return round(font.info.xHeight/2)
         else:
             raise AssertionError(origin)
 
+    def set_context(self, font, glyphSet):
+        ctx = super(TransformationsFilter, self).set_context(font, glyphSet)
+        ctx.origin_height = self.get_origin_height(font, self.options.Origin)
         return ctx
 
     @staticmethod

--- a/Lib/ufo2ft/filters/transformations.py
+++ b/Lib/ufo2ft/filters/transformations.py
@@ -1,0 +1,113 @@
+from __future__ import (
+    print_function, division, absolute_import, unicode_literals)
+
+import math
+from collections import namedtuple
+import logging
+
+from ufo2ft.filters import BaseFilter
+
+from fontTools.misc.py23 import round
+from fontTools.misc.transform import Identity
+from fontTools.pens.recordingPen import RecordingPen
+from fontTools.pens.transformPen import TransformPen
+
+
+# make do without the real Enum type, python3 only... :(
+def IntEnum(typename, field_names):
+    return namedtuple(typename, field_names)._make(
+        range(len(field_names)))
+
+
+log = logging.getLogger(__name__)
+
+
+class TransformationsFilter(BaseFilter):
+
+    Origin = IntEnum(
+        'Origin',
+        (
+            'CAP_HEIGHT',
+            'HALF_CAP_HEIGHT',
+            'X_HEIGHT',
+            'HALF_X_HEIGHT',
+            'BASELINE',
+        )
+    )
+
+    _kwargs = {
+        'OffsetX': 0,
+        'OffsetY': 0,
+        'ScaleX': 100,
+        'ScaleY': 100,
+        'Slant': 0,
+        'Origin': 4,  # BASELINE
+        'DEBUG': False,  # enables logging
+    }
+
+    def start(self):
+        if self.options.Origin not in self.Origin:
+            raise ValueError("%r is not a valid Origin value"
+                             % self.options.Origin)
+
+    def set_context(self, font, glyphSet):
+        origin = self.options.Origin
+        if origin is self.Origin.BASELINE:
+            value = 0
+        elif origin is self.Origin.CAP_HEIGHT:
+            value = font.info.capHeight
+        elif origin is self.Origin.HALF_CAP_HEIGHT:
+            value = round(font.info.capHeight/2)
+        elif origin is self.Origin.X_HEIGHT:
+            value = font.info.xHeight
+        elif origin is self.Origin.HALF_X_HEIGHT:
+            value = round(font.info.xHeight/2)
+        else:
+            raise AssertionError(origin)
+        return dict(origin_height=value)
+
+    @staticmethod
+    def transform(glyph, matrix):
+        if matrix == Identity:
+            return False
+
+        rec = RecordingPen()
+        glyph.draw(rec)
+        glyph.clearContours()
+        glyph.clearComponents()
+        rec.replay(TransformPen(glyph.getPen(), matrix))
+        # anchors are not drawn through the pen API,
+        # must be transformed separately
+        for a in glyph.anchors:
+            a.x, a.y = matrix.transformPoint((a.x, a.y))
+        return True
+
+    def filter(self, glyph):
+        if not (glyph or glyph.components or glyph.anchors):
+            return False  # skip empty
+
+        m = Identity
+        dx, dy = self.options.OffsetX, self.options.OffsetY
+        if dx != 0 or dy != 0:
+            m = m.translate(dx, dy)
+
+        sx, sy = self.options.ScaleX, self.options.ScaleY
+        angle = self.options.Slant
+        # TODO Add support for "Cursify" option
+        # cursify = self.options.SlantCorrection
+        if sx != 100 or sy != 100 or angle != 0:
+            # vertically shift glyph to the specified 'Origin' before
+            # scaling and/or slanting, then move it back
+            oy = self.context.origin_height
+            if oy != 0:
+                m = m.translate(0, oy)
+            if sx != 100 or sy != 100:
+                m = m.scale(sx/100, sy/100)
+            if angle != 0:
+                m = m.skew(math.radians(angle))
+            if oy != 0:
+                m = m.translate(0, -oy)
+
+        if self.options.DEBUG:
+            log.debug("transforming %r with %r", glyph.name, m)
+        return self.transform(glyph, m)

--- a/Lib/ufo2ft/filters/transformations.py
+++ b/Lib/ufo2ft/filters/transformations.py
@@ -51,20 +51,23 @@ class TransformationsFilter(BaseFilter):
                              % self.options.Origin)
 
     def set_context(self, font, glyphSet):
+        ctx = super(TransformationsFilter, self).set_context(font, glyphSet)
+
         origin = self.options.Origin
         if origin is self.Origin.BASELINE:
-            value = 0
+            ctx.origin_height = 0
         elif origin is self.Origin.CAP_HEIGHT:
-            value = font.info.capHeight
+            ctx.origin_height = font.info.capHeight
         elif origin is self.Origin.HALF_CAP_HEIGHT:
-            value = round(font.info.capHeight/2)
+            ctx.origin_height = round(font.info.capHeight/2)
         elif origin is self.Origin.X_HEIGHT:
-            value = font.info.xHeight
+            ctx.origin_height = font.info.xHeight
         elif origin is self.Origin.HALF_X_HEIGHT:
-            value = round(font.info.xHeight/2)
+            ctx.origin_height = round(font.info.xHeight/2)
         else:
             raise AssertionError(origin)
-        return dict(origin_height=value)
+
+        return ctx
 
     @staticmethod
     def transform(glyph, matrix):

--- a/tests/filters/transformations_test.py
+++ b/tests/filters/transformations_test.py
@@ -1,0 +1,165 @@
+from __future__ import print_function, division, absolute_import
+from ufo2ft.filters.transformations import TransformationsFilter, log
+from fontTools.misc.loggingTools import CapturingLogHandler
+from fontTools.misc.py23 import isclose
+import defcon
+import pytest
+
+
+@pytest.fixture(params=[
+    {
+        'capHeight': 700,
+        'xHeight': 500,
+        'glyphs': [
+            {
+                'name': 'space',
+                'width': 500,
+            },
+            {
+                'name': 'a',
+                'width': 350,
+                'outline': [
+                    ('moveTo', ((0, 0),)),
+                    ('lineTo', ((300, 0),)),
+                    ('lineTo', ((300, 300),)),
+                    ('lineTo', ((0, 300),)),
+                    ('closePath', ()),
+                ],
+                'anchors': [
+                    (100, 200, 'top'),
+                    (100, -200, 'bottom'),
+                ],
+            },
+            {
+                'name': 'b',
+                'width': 450,
+                'outline': [
+                    ('addComponent', ("a", (1, 0, 0, 1, 100, 200))),
+                ]
+            }
+        ],
+    }
+])
+def font(request):
+    font = defcon.Font()
+    font.info.capHeight = request.param['capHeight']
+    font.info.xHeight = request.param['xHeight']
+    for param in request.param['glyphs']:
+        glyph = font.newGlyph(param['name'])
+        glyph.width = param['width']
+        pen = glyph.getPen()
+        for operator, operands in param.get('outline', []):
+            getattr(pen, operator)(*operands)
+        for x, y, name in param.get('anchors', []):
+            glyph.appendAnchor(dict(x=x, y=y, name=name))
+    return font
+
+
+@pytest.fixture(
+    params=TransformationsFilter.Origin,
+    ids=TransformationsFilter.Origin._fields,
+)
+def origin(request):
+    return request.param
+
+
+class TransformationsFilterTest(object):
+
+    def test_invalid_origin_value(self):
+        with pytest.raises(ValueError) as excinfo:
+            TransformationsFilter(Origin=5)
+        excinfo.match("is not a valid Origin")
+
+    def test_empty_glyph(self, font):
+        filter_ = TransformationsFilter(OffsetY=51, include={'space'})
+        assert not filter_(font)
+
+    def test_Identity(self, font):
+        filter_ = TransformationsFilter()
+        assert not filter_(font)
+
+    def test_OffsetX(self, font):
+        filter_ = TransformationsFilter(OffsetX=-10)
+        assert filter_(font)
+
+        a = font["a"]
+        assert (a[0][0].x, a[0][0].y) == (-10, 0)
+        assert (a.anchors[1].x, a.anchors[1].y) == (90, -200)
+
+        font["b"].components[0].transformation[:2] == (90, 200)
+
+    def test_OffsetY(self, font):
+        filter_ = TransformationsFilter(OffsetY=51)
+        assert filter_(font)
+
+        a = font["a"]
+        assert (a[0][0].x, a[0][0].y) == (0, 51)
+        assert (a.anchors[1].x, a.anchors[1].y) == (100, -149)
+
+        font["b"].components[0].transformation[:2] == (100, 251)
+
+    def test_OffsetXY(self, font):
+        filter_ = TransformationsFilter(OffsetX=-10, OffsetY=51)
+        assert filter_(font)
+
+        a = font["a"]
+        assert (a[0][0].x, a[0][0].y) == (-10, 51)
+        assert (a.anchors[1].x, a.anchors[1].y) == (90, -149)
+
+        font["b"].components[0].transformation[:2] == (90, 251)
+
+    def test_ScaleX(self, font, origin):
+        # different Origin heights should not affect horizontal scale
+        filter_ = TransformationsFilter(ScaleX=50, Origin=origin)
+        assert filter_(font)
+
+        a = font["a"]
+        assert (a[0][0].x, a[0][0].y) == (0, 0)
+        assert (a[0][2].x, a[0][2].y) == (150, 300)
+
+    def test_ScaleY(self, font, origin):
+        percent = 50
+        filter_ = TransformationsFilter(ScaleY=percent, Origin=origin)
+        assert filter_(font)
+
+        factor = percent/100
+        origin_height = filter_.get_origin_height(font, origin)
+        bottom = origin_height * factor
+        top = bottom + 300 * factor
+
+        a = font["a"]
+        # only y coords change
+        assert (a[0][0].x, a[0][0].y) == (0, bottom)
+        assert (a[0][2].x, a[0][2].y) == (300, top)
+
+    def test_ScaleXY(self, font, origin):
+        percent = 50
+        filter_ = TransformationsFilter(
+            ScaleX=percent, ScaleY=percent, Origin=origin)
+        assert filter_(font)
+
+        factor = percent/100
+        origin_height = filter_.get_origin_height(font, origin)
+        bottom = origin_height * factor
+        top = bottom + 300 * factor
+
+        a = font["a"]
+        # both x and y change
+        assert (a[0][0].x, a[0][0].y) == (0, bottom)
+        assert (a[0][2].x, a[0][2].y) == (150, top)
+
+    def test_Slant(self, font, origin):
+        filter_ = TransformationsFilter(Slant=45, Origin=origin)
+        assert filter_(font)
+
+        origin_height = filter_.get_origin_height(font, origin)
+
+        a = font["a"]
+        assert isclose(a[0][0].x, -origin_height)
+        assert a[0][0].y == 0
+
+    def test_DEBUG(self, font):
+        filter_ = TransformationsFilter(OffsetY=10, DEBUG=True)
+        with CapturingLogHandler(log, level="DEBUG") as captor:
+            filter_(font)
+        assert captor.assertRegex("transforming")


### PR DESCRIPTION
Fixes https://github.com/googlei18n/ufo2ft/issues/120

the "Transformations" filter is meant to work like the one from Glyphs.app.
For now it only supports OffsetX, OffsetY, ScaleX, ScaleY, Slant and Origin options.
It doesn't support the "Cursify" (or SlantCorrection) option yet, nor the other options related to changing advance width and sidebearings. I will add those later.

I need this now to fix https://github.com/googlei18n/noto-source/issues/84 

check https://glyphsapp.com/downloads/handbook/Glyphs-Handbook-2.3.pdf (page 61) for more info on Transformations filter.

