### PR TITLE
read 'useProductionNames' key from UFO lib

### DIFF
--- a/Lib/ufo2ft/__init__.py
+++ b/Lib/ufo2ft/__init__.py
@@ -9,7 +9,7 @@ from ufo2ft.outlineCompiler import OutlineOTFCompiler, OutlineTTFCompiler
 from ufo2ft.postProcessor import PostProcessor
 
 
-__version__ = "1.0.0"
+__version__ = "1.0.1.dev0"
 
 
 def compileOTF(ufo, preProcessorClass=OTFPreProcessor,

--- a/Lib/ufo2ft/__init__.py
+++ b/Lib/ufo2ft/__init__.py
@@ -19,7 +19,7 @@ def compileOTF(ufo, preProcessorClass=OTFPreProcessor,
                markWriterClass=None,  # deprecated
                featureWriters=None,
                glyphOrder=None,
-               useProductionNames=True,
+               useProductionNames=None,
                optimizeCFF=True,
                roundTolerance=None,
                removeOverlaps=False,
@@ -41,6 +41,14 @@ def compileOTF(ufo, preProcessorClass=OTFPreProcessor,
       pre-initialized instances. Features will be written by each feature
       writer in the given order. If featureWriters is None, the default
       feature writers [KernFeatureWriter, MarkFeatureWriter] are used.
+
+    *useProductionNames* renames glyphs in TrueType 'post' or OpenType 'CFF '
+      tables based on the 'public.postscriptNames' mapping in the UFO lib,
+      if present. Otherwise, uniXXXX names are generated from the glyphs'
+      unicode values. The default value (None) will first check if the UFO lib
+      has the 'com.github.googlei18n.ufo2ft.useProductionNames' key. If this
+      is missing or True (default), the glyphs are renamed. Set to False
+      to keep the original names.
     """
     preProcessor = preProcessorClass(
         ufo, inplace=inplace, removeOverlaps=removeOverlaps)
@@ -71,7 +79,7 @@ def compileTTF(ufo, preProcessorClass=TTFPreProcessor,
                markWriterClass=None,  # deprecated
                featureWriters=None,
                glyphOrder=None,
-               useProductionNames=True,
+               useProductionNames=None,
                convertCubics=True,
                cubicConversionError=None,
                reverseDirection=True,
@@ -115,7 +123,7 @@ def compileInterpolatableTTFs(ufos,
                               featureCompilerClass=FeatureCompiler,
                               featureWriters=None,
                               glyphOrder=None,
-                              useProductionNames=True,
+                              useProductionNames=None,
                               cubicConversionError=None,
                               reverseDirection=True,
                               inplace=False):

--- a/Lib/ufo2ft/postProcessor.py
+++ b/Lib/ufo2ft/postProcessor.py
@@ -4,6 +4,9 @@ from fontTools.misc.py23 import BytesIO
 from fontTools.ttLib import TTFont
 
 
+UFO2FT_PREFIX = 'com.github.googlei18n.ufo2ft.'
+
+
 class PostProcessor(object):
     """Does some post-processing operations on a compiled OpenType font, using
     info from the source UFO where necessary.
@@ -17,7 +20,20 @@ class PostProcessor(object):
         self.otf = TTFont(stream)
         self._postscriptNames = ufo.lib.get('public.postscriptNames')
 
-    def process(self, useProductionNames=True, optimizeCFF=True):
+    def process(self, useProductionNames=None, optimizeCFF=True):
+        """
+        useProductionNames:
+          Rename glyphs using using 'public.postscriptNames' in UFO lib,
+          if present. Else, generate uniXXXX names from the glyphs' unicode.
+          If 'com.github.googlei18n.ufo2ft.useProductionNames' key in the UFO
+          lib is present and is set to False, do not modify the glyph names.
+
+        optimizeCFF:
+          Run compreffor to subroubtinize CFF table, if present.
+        """
+        if useProductionNames is None:
+            useProductionNames = self.ufo.lib.get(
+                UFO2FT_PREFIX + "useProductionNames", True)
         if useProductionNames:
             self._rename_glyphs_from_ufo()
         if optimizeCFF and 'CFF ' in self.otf:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0
+current_version = 1.0.1.dev0
 commit = True
 tag = False
 tag_name = v{new_version}

--- a/setup.py
+++ b/setup.py
@@ -145,7 +145,7 @@ with open('README.rst', 'r') as f:
 
 setup(
     name="ufo2ft",
-    version="1.0.0",
+    version="1.0.1.dev0",
     author="Tal Leming, James Godfrey-Kittle",
     author_email="tal@typesupply.com",
     maintainer="James Godfrey-Kittle",

--- a/tests/outlineCompiler_test.py
+++ b/tests/outlineCompiler_test.py
@@ -305,19 +305,31 @@ class TestNames(unittest.TestCase):
         self.ufo = getTestUFO()
 
     def test_compile_without_production_names(self):
+        expected = ['.notdef', 'space', 'a', 'b', 'c', 'd',
+                    'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l']
+
         result = compileTTF(self.ufo, useProductionNames=False)
-        self.assertEqual(result.getGlyphOrder(),
-                         ['.notdef', 'space', 'a', 'b', 'c', 'd',
-                          'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l'])
+        self.assertEqual(result.getGlyphOrder(), expected)
+
+        self.ufo.lib["com.github.googlei18n.ufo2ft.useProductionNames"] = False
+        result = compileTTF(self.ufo)
+        self.assertEqual(result.getGlyphOrder(), expected)
 
     def test_compile_with_production_names(self):
+        expected = ['.notdef', 'uni0020', 'uni0061', 'uni0062',
+                    'uni0063', 'uni0064', 'uni0065', 'uni0066',
+                    'uni0067', 'uni0068', 'uni0069', 'uni006A',
+                    'uni006B', 'uni006C']
+
+        result = compileTTF(self.ufo)
+        self.assertEqual(result.getGlyphOrder(), expected)
+
         result = compileTTF(self.ufo, useProductionNames=True)
-        self.assertEqual(result.getGlyphOrder(),
-                         ['.notdef', 'uni0020', 'uni0061', 'uni0062',
-                          'uni0063', 'uni0064', 'uni0065', 'uni0066',
-                          'uni0067', 'uni0068', 'uni0069', 'uni006A',
-                          'uni006B', 'uni006C',
-                         ])
+        self.assertEqual(result.getGlyphOrder(), expected)
+
+        self.ufo.lib["com.github.googlei18n.ufo2ft.useProductionNames"] = True
+        result = compileTTF(self.ufo)
+        self.assertEqual(result.getGlyphOrder(), expected)
 
     CUSTOM_POSTSCRIPT_NAMES = {
             '.notdef': '.notdef',


### PR DESCRIPTION
This is the same as what fontmake currently does with the Glyphs.app's specific "Don't use Production Names", only that we use a new ufo2ft specific key, without apostrophes or spaces in the name (which look odd) and we use a positive value instead of negative for clarity's sake.

https://github.com/googlei18n/fontmake/blob/6cdf44ea38d17f9bb14fa65c1c9bc6ea82e3b89b/Lib/fontmake/font_project.py#L272-L274

The default behaviour of ufo2ft doesn't change. It still does the post/CFF renaming by default, trying the postscriptNames dict if present or falling back to the glyphs' unicodes. However, when this new lib key "com.github.googlei18n.ufo2ft.useProductionNames" is present and set to False, the renaming is disabled.