### PR TITLE
Fallback to SOURCE_DATE_EPOCH for openTypeHeadCreated if available

### DIFF
--- a/Lib/ufo2ft/fontInfoData.py
+++ b/Lib/ufo2ft/fontInfoData.py
@@ -15,8 +15,10 @@ from __future__ import print_function, division, absolute_import, unicode_litera
 
 import logging
 import math
+from datetime import datetime
 import time
 import unicodedata
+import os
 
 from fontTools.misc.py23 import tobytes, tostr, tounicode, unichr, round, round2
 from fontTools.misc.textTools import binary2num
@@ -55,9 +57,14 @@ def dateStringForNow():
 
 def openTypeHeadCreatedFallback(info):
     """
-    Fallback to now.
+    Fallback to the environment variable SOURCE_DATE_EPOCH if set, otherwise
+    now.
     """
-    return dateStringForNow()
+    if "SOURCE_DATE_EPOCH" in os.environ:
+        t = datetime.fromtimestamp(int(os.environ["SOURCE_DATE_EPOCH"]))
+        return t.strftime("%Y/%m/%d %H:%M:%S")
+    else:
+        return dateStringForNow()
 
 # hhea
 

--- a/tests/fontInfoData_test.py
+++ b/tests/fontInfoData_test.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division, absolute_import, unicode_literals
 
 import unittest
+import os
 from ufo2ft.fontInfoData import (
     getAttrWithFallback,
     normalizeStringForPostscript)
@@ -104,6 +105,16 @@ class GetAttrWithFallbackTest(unittest.TestCase):
         self.assertEqual(
             getAttrWithFallback(info, "openTypeHheaCaretSlopeRun"), 200)
 
+    def test_head_created(self):
+        info = TestInfoObject()
+
+        os.environ["SOURCE_DATE_EPOCH"] = '1514485183'
+        self.assertEqual(
+            getAttrWithFallback(info, "openTypeHeadCreated"), '2017/12/28 18:19:43')
+        del os.environ["SOURCE_DATE_EPOCH"]
+        self.assertNotEqual(
+            getAttrWithFallback(info, "openTypeHeadCreated"), '2017/12/28 18:19:43')
+
 
 class PostscriptBlueScaleFallbackTest(unittest.TestCase):
 
@@ -144,4 +155,3 @@ class TestInfoObject(object):
 if __name__ == "__main__":
     import sys
     sys.exit(unittest.main())
-

--- a/tests/fontInfoData_test.py
+++ b/tests/fontInfoData_test.py
@@ -109,11 +109,15 @@ class GetAttrWithFallbackTest(unittest.TestCase):
         info = TestInfoObject()
 
         os.environ["SOURCE_DATE_EPOCH"] = '1514485183'
-        self.assertEqual(
-            getAttrWithFallback(info, "openTypeHeadCreated"), '2017/12/28 18:19:43')
-        del os.environ["SOURCE_DATE_EPOCH"]
+        try:
+            self.assertEqual(
+                getAttrWithFallback(info, "openTypeHeadCreated"),
+                '2017/12/28 18:19:43')
+        finally:
+            del os.environ["SOURCE_DATE_EPOCH"]
         self.assertNotEqual(
-            getAttrWithFallback(info, "openTypeHeadCreated"), '2017/12/28 18:19:43')
+            getAttrWithFallback(info, "openTypeHeadCreated"),
+            '2017/12/28 18:19:43')
 
 
 class PostscriptBlueScaleFallbackTest(unittest.TestCase):


### PR DESCRIPTION
That way, SOURCE_DATE_EPOCH can be used for reproducible builds if
openTypeHeadCreated does not exist.