### PR TITLE
[kernFeatureWriter] always write default kern_ltr lookup if non-empty

### DIFF
--- a/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/kernFeatureWriter.py
@@ -95,18 +95,17 @@ class KernFeatureWriter(BaseFeatureWriter):
         # write the lookups and feature
         ltrScripts = self.context.ltrScripts
         ltrKern = []
-        if ltrScripts or not rtlScripts:
-            self._addKerning(ltrKern,
-                             self.context.glyphPairKerning)
-            self._addKerning(ltrKern,
-                             self.context.leftClassKerning,
-                             enum=True)
-            self._addKerning(ltrKern,
-                             self.context.rightClassKerning,
-                             enum=True)
-            self._addKerning(ltrKern,
-                             self.context.classPairKerning,
-                             ignoreZero=True)
+        self._addKerning(ltrKern,
+                         self.context.glyphPairKerning)
+        self._addKerning(ltrKern,
+                         self.context.leftClassKerning,
+                         enum=True)
+        self._addKerning(ltrKern,
+                         self.context.rightClassKerning,
+                         enum=True)
+        self._addKerning(ltrKern,
+                         self.context.classPairKerning,
+                         ignoreZero=True)
         if ltrKern:
             lines.append("lookup kern_ltr {")
             if self.options.ignoreMarks:
@@ -147,11 +146,8 @@ class KernFeatureWriter(BaseFeatureWriter):
         lines.append("feature kern {")
         if ltrKern:
             lines.append("    lookup kern_ltr;")
-        if rtlScripts:
-            if ltrKern:
-                self._addLookupReferences(lines, ltrScripts, "kern_ltr")
-            if rtlKern:
-                self._addLookupReferences(lines, rtlScripts, "kern_rtl")
+        if rtlKern:
+            self._addLookupReferences(lines, rtlScripts, "kern_rtl")
         lines.append("} kern;")
 
         return self.linesep.join(lines)

--- a/tests/kernFeatureWriter_test.py
+++ b/tests/kernFeatureWriter_test.py
@@ -126,7 +126,6 @@ class KernFeatureWriterTest(unittest.TestCase):
             } kern;""")
 
     # https://github.com/googlei18n/ufo2ft/issues/198
-    @unittest.expectedFailure
     def test_arabic_numerals(self):
         ufo = Font()
         for name, code in [("four-ar", 0x664), ("seven-ar", 0x667)]:


### PR DESCRIPTION
Partly fixes #198 

This allows to write kerning pairs between arabic numerals (in the LTR lookup) when no LTR languagesystem is explicitly defined, but only some RTL languagesystems (as in NotoSansArabic).

Also, there's no need to duplicate the lookup references to kern_ltr for LTR scripts and languages, since the kern_ltr lookup appears before any scripts statements and thus will be automatically registered for all defined languagesystems.