### PR TITLE
[featureWriters] add "prepend" mode

### DIFF
--- a/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
+++ b/Lib/ufo2ft/featureWriters/baseFeatureWriter.py
@@ -3,7 +3,7 @@ from __future__ import (
 from fontTools.misc.py23 import SimpleNamespace
 
 
-_SUPPORTED_MODES = ("skip", "append")
+_SUPPORTED_MODES = ("skip", "append", "prepend")
 
 
 class BaseFeatureWriter(object):
@@ -19,7 +19,10 @@ class BaseFeatureWriter(object):
     1) "skip" (default) will not write anything if any of the features
        listed is already present;
     2) "append" will add additional lookups to an existing feature,
-       if it's already present.
+       if present, or it will add a new one at the end of all features.
+    3) "prepend" will add additional lookups to an existing feature
+       before an already existing one, or will add a new one at the
+       beginning of the features.
 
     The 'options' class attribute contains a mapping of option
     names with their default values. These can be overridden on an

--- a/tests/kernFeatureWriter_test.py
+++ b/tests/kernFeatureWriter_test.py
@@ -125,6 +125,22 @@ class KernFeatureWriterTest(unittest.TestCase):
                 lookup kern_ltr;
             } kern;""")
 
+        writer = KernFeatureWriter(mode="prepend")
+        compiler = FeatureCompiler(ufo, outline, featureWriters=[writer])
+        compiler.setupFile_features()
+
+        assert compiler.features == dedent("""
+            lookup kern_ltr {
+                lookupflag IgnoreMarks;
+                pos seven six 25;
+            } kern_ltr;
+
+            feature kern {
+                lookup kern_ltr;
+            } kern;
+
+            """) + existing
+
     # https://github.com/googlei18n/ufo2ft/issues/198
     @unittest.expectedFailure
     def test_arabic_numerals(self):


### PR DESCRIPTION
Glyphs.app prepends the auto-generated kern feature code to the user-defined one, we need to support this.

https://github.com/googlei18n/ufo2ft/issues/187#issuecomment-355581954