### PR TITLE
Support no-contour glyphs

### DIFF
--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -611,9 +611,9 @@ class BaseOutlineCompiler(object):
             extent = left + (bounds.xMax - bounds.xMin)
             extents.append(extent)
         hhea.advanceWidthMax = max(widths)
-        hhea.minLeftSideBearing = min(lefts)
-        hhea.minRightSideBearing = min(rights)
-        hhea.xMaxExtent = max(extents)
+        hhea.minLeftSideBearing = min(lefts) if lefts else 0
+        hhea.minRightSideBearing = min(rights) if rights else 0
+        hhea.xMaxExtent = max(extents) if extents else 0
         # misc
         hhea.caretSlopeRise = getAttrWithFallback(font.info, "openTypeHheaCaretSlopeRise")
         hhea.caretSlopeRun = getAttrWithFallback(font.info, "openTypeHheaCaretSlopeRun")

--- a/tests/outlineCompiler_test.py
+++ b/tests/outlineCompiler_test.py
@@ -91,6 +91,16 @@ class OutlineTTFCompilerTest(unittest.TestCase):
         self.assertEqual(otf["CUST"].data, b"\x00\x01\xbe\xef")
         self.assertEqual(otf.sfntVersion, "\x00\x01\x00\x00")
 
+    def test_no_contour_glyphs(self):
+        for glyph in self.ufo:
+            glyph.clearContours()
+        compiler = OutlineTTFCompiler(self.ufo)
+        compiler.compile()
+        self.assertEqual(compiler.otf['hhea'].advanceWidthMax, 600)
+        self.assertEqual(compiler.otf['hhea'].minLeftSideBearing, 0)
+        self.assertEqual(compiler.otf['hhea'].minRightSideBearing, 0)
+        self.assertEqual(compiler.otf['hhea'].xMaxExtent, 0)
+
 
 class OutlineOTFCompilerTest(unittest.TestCase):
 
@@ -264,6 +274,16 @@ class OutlineOTFCompilerTest(unittest.TestCase):
         self.assertIn("CUST", otf)
         self.assertEqual(otf["CUST"].data, b"\x00\x01\xbe\xef")
         self.assertEqual(otf.sfntVersion, "OTTO")
+
+    def test_no_contour_glyphs(self):
+        for glyph in self.ufo:
+            glyph.clearContours()
+        compiler = OutlineOTFCompiler(self.ufo)
+        compiler.compile()
+        self.assertEqual(compiler.otf['hhea'].advanceWidthMax, 600)
+        self.assertEqual(compiler.otf['hhea'].minLeftSideBearing, 0)
+        self.assertEqual(compiler.otf['hhea'].minRightSideBearing, 0)
+        self.assertEqual(compiler.otf['hhea'].xMaxExtent, 0)
 
 
 class TestGlyphOrder(unittest.TestCase):


### PR DESCRIPTION
outlineCompiler was failing when given a no-contour-glyphs-only font.