### PR TITLE
Please make .OTF generation reproducible.

### DIFF
--- a/Lib/ufo2ft/fontInfoData.py
+++ b/Lib/ufo2ft/fontInfoData.py
@@ -15,7 +15,7 @@ from __future__ import print_function, division, absolute_import, unicode_litera
 
 import logging
 import math
-from datetime import datetime
+from datetime import datetime, tzinfo, timedelta
 import time
 import unicodedata
 import os
@@ -521,9 +521,19 @@ def intListToNum(intList, start, length):
     all = " ".join(all)
     return binary2num(all)
 
+class UTC(tzinfo):
+    def utcoffset(self, dt):
+        return timedelta(0)
+
+    def tzname(self, dt):
+        return "UTC"
+
+    def dst(self, dt):
+        return timedelta(0)
+
 def dateStringToTimeValue(date):
     try:
-        t = time.strptime(date, "%Y/%m/%d %H:%M:%S")
-        return int(time.mktime(t))
-    except OverflowError:
+        t = datetime.strptime(date, "%Y/%m/%d %H:%M:%S").replace(tzinfo=UTC())
+        return int(time.mktime(t.timetuple()))
+    except ValueError:
         return 0


### PR DESCRIPTION
Whilst working on the [Reproducible Builds effort](https://reproducible-builds.org/), we noticed that ufo2ft generates ``.otf`` files that are not reproducible.

For example, here is ``showotf`` output of the ``league-spartan`` font:

```
│ │ │ │ │  HEAD table (at 188)
│ │ │ │ │  	Version=1
│ │ │ │ │  	fontRevision=2
│ │ │ │ │ -	checksumAdj=e32dbbe4
│ │ │ │ │ +	checksumAdj=e3309724
│ │ │ │ │  	magicNumber=5f0f3cf5 (0x5f0f3cf5, diff=0)
│ │ │ │ │  	flags=3 baseline_at_0 lsb_at_0
│ │ │ │ │  	unitsPerEm=1250
│ │ │ │ │  	create[0]=0
│ │ │ │ │ -	 create[1]=d580d7b0
│ │ │ │ │ -	File created: Tue Jul  4 05:27:12 2017
│ │ │ │ │ +	 create[1]=d57f6a10
│ │ │ │ │ +	File created: Mon Jul  3 03:27:12 2017
```

… which shows that it varies on the local timezone.

This has also been filed in Debian as [#890280](https://bugs.debian.org/890280)