### PR TITLE
Add filter to propagate anchors

### DIFF
--- a/Lib/ufo2ft/filters/propagateAnchors.py
+++ b/Lib/ufo2ft/filters/propagateAnchors.py
@@ -82,7 +82,10 @@ def _propagate_glyph_anchors(font, composite, processed):
     # we sort propagated anchors to append in a deterministic order
     for name, (x, y) in sorted(to_add.items()):
         anchor_dict = {'name': name, 'x': x, 'y': y}
-        parent.appendAnchor(glyph.anchorClass(anchorDict=anchor_dict))
+        try:
+            composite.appendAnchor(anchor_dict)
+        except TypeError:
+            composite.appendAnchor(name, (x, y))
 
 
 def _get_anchor_data(anchor_data, font, components, anchor_name):

--- a/Lib/ufo2ft/filters/propagateAnchors.py
+++ b/Lib/ufo2ft/filters/propagateAnchors.py
@@ -84,7 +84,8 @@ def _propagate_glyph_anchors(font, composite, processed):
         anchor_dict = {'name': name, 'x': x, 'y': y}
         try:
             composite.appendAnchor(anchor_dict)
-        except TypeError:
+        except TypeError:  # pragma: no cover
+            # fontParts API
             composite.appendAnchor(name, (x, y))
 
 

--- a/Lib/ufo2ft/filters/propagateAnchors.py
+++ b/Lib/ufo2ft/filters/propagateAnchors.py
@@ -39,7 +39,7 @@ class PropagateAnchorsFilter(BaseFilter):
     def filter(self, glyph):
         if not glyph.components:
             return False
-        _propagate_glyph_anchors(glyph.font, glyph, self.context.processed)
+        _propagate_glyph_anchors(self.context.font, glyph, self.context.processed)
         return True
 
 

--- a/Lib/ufo2ft/filters/propagateAnchors.py
+++ b/Lib/ufo2ft/filters/propagateAnchors.py
@@ -54,6 +54,9 @@ def _propagate_glyph_anchors(font, composite, processed):
         return
     processed.add(composite.name)
 
+    if not composite.components:
+        return
+
     base_components = []
     mark_components = []
     anchor_names = set()

--- a/Lib/ufo2ft/filters/propagateAnchors.py
+++ b/Lib/ufo2ft/filters/propagateAnchors.py
@@ -1,0 +1,111 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from fontTools.misc.transform import Transform
+from ufo2ft.filters import BaseFilter
+
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+class PropagateAnchorsFilter(BaseFilter):
+
+    def set_context(self, font, glyphSet):
+        ctx = super(PropagateAnchorsFilter, self).set_context(font, glyphSet)
+        ctx.processed = set()
+        return ctx
+
+    def __call__(self, font, glyphSet=None):
+        if super(PropagateAnchorsFilter, self).__call__(font, glyphSet):
+            modified = self.context.modified
+            if modified:
+                logger.info('Glyphs with propagated anchors: %i' %
+                            len(modified))
+            return modified
+
+    def filter(self, glyph):
+        if not glyph.components:
+            return False
+        _propagate_glyph_anchors(glyph.font, glyph, self.context.processed)
+        return True
+
+
+def _propagate_glyph_anchors(ufo, parent, processed):
+    """Propagate anchors for a single parent glyph."""
+
+    if parent.name in processed:
+        return
+    processed.add(parent.name)
+
+    base_components = []
+    mark_components = []
+    anchor_names = set()
+    to_add = {}
+    for component in parent.components:
+        glyph = ufo[component.baseGlyph]
+        _propagate_glyph_anchors(ufo, glyph, processed)
+        if any(a.name.startswith('_') for a in glyph.anchors):
+            mark_components.append(component)
+        else:
+            base_components.append(component)
+            anchor_names |= {a.name for a in glyph.anchors}
+
+    for anchor_name in anchor_names:
+        # don't add if parent already contains this anchor OR any associated
+        # ligature anchors (e.g. "top_1, top_2" for "top")
+        if not any(a.name.startswith(anchor_name) for a in parent.anchors):
+            _get_anchor_data(to_add, ufo, base_components, anchor_name)
+
+    for component in mark_components:
+        _adjust_anchors(to_add, ufo, component)
+
+    # we sort propagated anchors to append in a deterministic order
+    for name, (x, y) in sorted(to_add.items()):
+        anchor_dict = {'name': name, 'x': x, 'y': y}
+        parent.appendAnchor(glyph.anchorClass(anchorDict=anchor_dict))
+
+
+def _get_anchor_data(anchor_data, ufo, components, anchor_name):
+    """Get data for an anchor from a list of components."""
+
+    anchors = []
+    for component in components:
+        for anchor in ufo[component.baseGlyph].anchors:
+            if anchor.name == anchor_name:
+                anchors.append((anchor, component))
+                break
+    if len(anchors) > 1:
+        for i, (anchor, component) in enumerate(anchors):
+            t = Transform(*component.transformation)
+            name = '%s_%d' % (anchor.name, i + 1)
+            anchor_data[name] = t.transformPoint((anchor.x, anchor.y))
+    elif anchors:
+        anchor, component = anchors[0]
+        t = Transform(*component.transformation)
+        anchor_data[anchor.name] = t.transformPoint((anchor.x, anchor.y))
+
+
+def _adjust_anchors(anchor_data, ufo, component):
+    """Adjust anchors to which a mark component may have been attached."""
+
+    glyph = ufo[component.baseGlyph]
+    t = Transform(*component.transformation)
+    for anchor in glyph.anchors:
+        # only adjust if this anchor has data and the component also contains
+        # the associated mark anchor (e.g. "_top" for "top")
+        if (anchor.name in anchor_data and
+                any(a.name == '_' + anchor.name for a in glyph.anchors)):
+            anchor_data[anchor.name] = t.transformPoint((anchor.x, anchor.y))

--- a/Lib/ufo2ft/filters/propagateAnchors.py
+++ b/Lib/ufo2ft/filters/propagateAnchors.py
@@ -39,7 +39,8 @@ class PropagateAnchorsFilter(BaseFilter):
     def filter(self, glyph):
         if not glyph.components:
             return False
-        _propagate_glyph_anchors(self.context.font, glyph, self.context.processed)
+        _propagate_glyph_anchors(self.context.font, glyph,
+                                 self.context.processed)
         return True
 
 

--- a/tests/filters/propagateAnchors_test.py
+++ b/tests/filters/propagateAnchors_test.py
@@ -76,6 +76,9 @@ import pytest
                     ('addComponent', ('a', (1, 0, 0, 1, 0, 0))),
                     ('addComponent', ('macroncomb', (1, 0, 0, 1, 175, 0))),
                 ],
+                'anchors': [
+                    (176, 481, 'top'),
+                ],
             },
             {
                 'name': 'adieresis',
@@ -100,6 +103,14 @@ import pytest
                     ('addComponent', ('a', (1, 0, 0, 1, 0, 0))),
                     ('addComponent', ('dieresiscomb', (1, 0, 0, 1, 175, 0))),
                     ('addComponent', ('macroncomb', (1, 0, 0, 1, 175, 180))),
+                ],
+            },
+            {
+                'name': 'a_a',
+                'width': 700,
+                'outline': [
+                    ('addComponent', ('a', (1, 0, 0, 1, 0, 0))),
+                    ('addComponent', ('a', (1, 0, 0, 1, 350, 0))),
                 ],
             },
         ],
@@ -138,13 +149,23 @@ class PropagateAnchorsFilterTest(object):
         )
 
     def test_two_component_glyph(self, font):
-        name = 'amacron'
+        name = 'adieresis'
         philter = PropagateAnchorsFilter(include={name})
         assert philter(font) == {name}
         assert (
             [(a.name, a.x, a.y) for a in font[name].anchors] ==
             [('bottom', 175, 0),
              ('top', 175, 480)]
+        )
+
+    def test_one_anchor_two_component_glyph(self, font):
+        name = 'amacron'
+        philter = PropagateAnchorsFilter(include={name})
+        assert philter(font) == {name}
+        assert (
+            [(a.name, a.x, a.y) for a in font[name].anchors] ==
+            [('top', 176, 481),
+             ('bottom', 175, 0)]
         )
 
     def test_three_component_glyph(self, font):
@@ -166,15 +187,27 @@ class PropagateAnchorsFilterTest(object):
             [('bottom', 175, 0),
              ('top', 175, 660)]
         )
+    def test_ligature_glyph(self, font):
+        name = 'a_a'
+        philter = PropagateAnchorsFilter(include={name})
+        assert philter(font) == {name}
+        assert (
+            [(a.name, a.x, a.y) for a in font[name].anchors] ==
+            [('bottom_1', 175, 0),
+             ('bottom_2', 525, 0),
+             ('top_1', 175, 300),
+             ('top_2', 525, 300)]
+        )
 
     def test_whole_font(self, font):
         philter = PropagateAnchorsFilter()
         modified = philter(font)
         assert modified == set(['a-cyr', 'amacron', 'adieresis',
-                                'adieresismacron', 'amacrondieresis'])
+                                'adieresismacron', 'amacrondieresis',
+                                'a_a'])
 
     def test_logger(self, font):
         with CapturingLogHandler(logger, level="INFO") as captor:
             philter = PropagateAnchorsFilter()
             modified = philter(font)
-        captor.assertRegex('Glyphs with propagated anchors: 5')
+        captor.assertRegex('Glyphs with propagated anchors: 6')

--- a/tests/filters/propagateAnchors_test.py
+++ b/tests/filters/propagateAnchors_test.py
@@ -1,0 +1,180 @@
+from __future__ import print_function, division, absolute_import
+from ufo2ft.filters.propagateAnchors import PropagateAnchorsFilter, logger
+from fontTools.misc.loggingTools import CapturingLogHandler
+import defcon
+import pytest
+
+
+@pytest.fixture(params=[
+    {
+        'glyphs': [
+            {
+                'name': 'space',
+                'width': 500,
+            },
+            {
+                'name': 'a',
+                'width': 350,
+                'outline': [
+                    ('moveTo', ((0, 0),)),
+                    ('lineTo', ((300, 0),)),
+                    ('lineTo', ((300, 300),)),
+                    ('lineTo', ((0, 300),)),
+                    ('closePath', ()),
+                ],
+                'anchors': [
+                    (175, 300, 'top'),
+                    (175, 0, 'bottom'),
+                ],
+            },
+            {
+                'name': 'dieresiscomb',
+                'width': 0,
+                'outline': [
+                    ('moveTo', ((-120, 320),)),
+                    ('lineTo', ((-60, 320),)),
+                    ('lineTo', ((-60, 360),)),
+                    ('lineTo', ((-120, 360),)),
+                    ('closePath', ()),
+                    ('moveTo', ((120, 320),)),
+                    ('lineTo', ((60, 320),)),
+                    ('lineTo', ((60, 360),)),
+                    ('lineTo', ((120, 360),)),
+                    ('closePath', ()),
+                ],
+                'anchors': [
+                    (0, 300, '_top'),
+                    (0, 480, 'top'),
+                ],
+            },
+            {
+                'name': 'macroncomb',
+                'width': 0,
+                'outline': [
+                    ('moveTo', ((-120, 330),)),
+                    ('lineTo', ((120, 330),)),
+                    ('lineTo', ((120, 350),)),
+                    ('lineTo', ((-120, 350),)),
+                    ('closePath', ()),
+                ],
+                'anchors': [
+                    (0, 300, '_top'),
+                    (0, 480, 'top'),
+                ],
+            },
+            {
+                'name': 'a-cyr',
+                'width': 350,
+                'outline': [
+                    ('addComponent', ('a', (1, 0, 0, 1, 0, 0))),
+                ],
+            },
+            {
+                'name': 'amacron',
+                'width': 350,
+                'outline': [
+                    ('addComponent', ('a', (1, 0, 0, 1, 0, 0))),
+                    ('addComponent', ('macroncomb', (1, 0, 0, 1, 175, 0))),
+                ],
+            },
+            {
+                'name': 'adieresis',
+                'width': 350,
+                'outline': [
+                    ('addComponent', ('a', (1, 0, 0, 1, 0, 0))),
+                    ('addComponent', ('dieresiscomb', (1, 0, 0, 1, 175, 0))),
+                ],
+            },
+            {
+                'name': 'amacrondieresis',
+                'width': 350,
+                'outline': [
+                    ('addComponent', ('amacron', (1, 0, 0, 1, 0, 0))),
+                    ('addComponent', ('dieresiscomb', (1, 0, 0, 1, 175, 180))),
+                ],
+            },
+            {
+                'name': 'adieresismacron',
+                'width': 350,
+                'outline': [
+                    ('addComponent', ('a', (1, 0, 0, 1, 0, 0))),
+                    ('addComponent', ('dieresiscomb', (1, 0, 0, 1, 175, 0))),
+                    ('addComponent', ('macroncomb', (1, 0, 0, 1, 175, 180))),
+                ],
+            },
+        ],
+    }
+])
+def font(request):
+    font = defcon.Font()
+    for param in request.param['glyphs']:
+        glyph = font.newGlyph(param['name'])
+        glyph.width = param.get('width', 0)
+        pen = glyph.getPen()
+        for operator, operands in param.get('outline', []):
+            getattr(pen, operator)(*operands)
+        for x, y, name in param.get('anchors', []):
+            glyph.appendAnchor(dict(x=x, y=y, name=name))
+    return font
+
+
+class PropagateAnchorsFilterTest(object):
+
+    def test_empty_glyph(self, font):
+        philter = PropagateAnchorsFilter(include={'space'})
+        assert not philter(font)
+
+    def test_contour_glyph(self, font):
+        philter = PropagateAnchorsFilter(include={'a'})
+        assert not philter(font)
+
+    def test_single_component_glyph(self, font):
+        philter = PropagateAnchorsFilter(include={'a-cyr'})
+        assert philter(font) == {'a-cyr'}
+        assert (
+            [(a.name, a.x, a.y) for a in font['a-cyr'].anchors] ==
+            [('bottom', 175, 0),
+             ('top', 175, 300)]
+        )
+
+    def test_two_component_glyph(self, font):
+        name = 'amacron'
+        philter = PropagateAnchorsFilter(include={name})
+        assert philter(font) == {name}
+        assert (
+            [(a.name, a.x, a.y) for a in font[name].anchors] ==
+            [('bottom', 175, 0),
+             ('top', 175, 480)]
+        )
+
+    def test_three_component_glyph(self, font):
+        name = 'adieresismacron'
+        philter = PropagateAnchorsFilter(include={name})
+        assert philter(font) == {name}
+        assert (
+            [(a.name, a.x, a.y) for a in font[name].anchors] ==
+            [('bottom', 175, 0),
+             ('top', 175, 660)]
+        )
+
+    def test_nested_component_glyph(self, font):
+        name = 'amacrondieresis'
+        philter = PropagateAnchorsFilter(include={name})
+        assert philter(font) == {name}
+        assert (
+            [(a.name, a.x, a.y) for a in font[name].anchors] ==
+            [('bottom', 175, 0),
+             ('top', 175, 660)]
+        )
+
+    def test_whole_font(self, font):
+        philter = PropagateAnchorsFilter()
+        modified = philter(font)
+        assert modified == set(['a-cyr', 'amacron', 'adieresis',
+                                'adieresismacron', 'amacrondieresis'])
+
+    def test_logger(self, font):
+        with CapturingLogHandler(logger, level="INFO") as captor:
+            philter = PropagateAnchorsFilter()
+            modified = philter(font)
+        captor.assertRegex('Glyphs with propagated anchors: 5')


### PR DESCRIPTION
Fixes  #170 by turning [glyphsLib’s anchors propagation](https://github.com/googlei18n/glyphsLib/blob/98fb2dce8e5a808aed83595c5e5cc359064ddb9e/Lib/glyphsLib/builder/anchors.py) into a ufo2ft filter.