### PR TITLE
outlineCompiler: use optimizeWidths to compute CFF default/nominalWidthX

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fonttools==3.22.0
+fonttools==3.23.0
 ufoLib==2.1.1
 defcon==0.3.5
 cu2qu==1.4.0

--- a/setup.py
+++ b/setup.py
@@ -166,7 +166,7 @@ setup(
         'pytest>=2.8',
     ],
     install_requires=[
-        "fonttools>=3.17.0",
+        "fonttools>=3.23.0",
         "ufoLib>=2.1.0",
         "defcon>=0.3.4",
         "cu2qu>=1.2.0",


### PR DESCRIPTION
`fontTools.cffLib.width` module was added with fonttools 3.23.0, so we should probably also bump the fonttools minimum installation requirement in ufo2ft's setup.py. Unless we prefer not to do that, and we attempt to import the new module and use it if it's there, else fallback to the old behavior.

I'd also like to add some tests before merging this.

Fixes #216