### PR TITLE
Update vhea and share logic with hhea

### DIFF
--- a/Lib/ufo2ft/fontInfoData.py
+++ b/Lib/ufo2ft/fontInfoData.py
@@ -325,9 +325,12 @@ staticFallbackData = dict(
     openTypeVheaVertTypoAscender=None,
     openTypeVheaVertTypoDescender=None,
     openTypeVheaVertTypoLineGap=None,
-    openTypeVheaCaretSlopeRise=None,
-    openTypeVheaCaretSlopeRun=None,
-    openTypeVheaCaretOffset=None,
+    # fallback to horizontal caret:
+    # a value of 0 for the rise
+    # and a value of 1 for the run.
+    openTypeVheaCaretSlopeRise=0,
+    openTypeVheaCaretSlopeRun=1,
+    openTypeVheaCaretOffset=0,
 
     postscriptUniqueID=None,
     postscriptWeightName=None,

--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -41,13 +41,13 @@ def _isNonBMP(s):
     return False
 
 
-def _getVerticalOrigin(glyph):
-    height = glyph.height
+def _getVerticalOrigin(font, glyph):
+    font_ascender = font['hhea'].ascent
     if (hasattr(glyph, "verticalOrigin") and
             glyph.verticalOrigin is not None):
         verticalOrigin = glyph.verticalOrigin
     else:
-        verticalOrigin = height
+        verticalOrigin = font_ascender
     return round(verticalOrigin)
 
 
@@ -655,7 +655,7 @@ class BaseOutlineCompiler(object):
             if height < 0:
                 raise ValueError(
                     "The height should not be negative: '%s'" % (glyphName))
-            verticalOrigin = _getVerticalOrigin(glyph)
+            verticalOrigin = _getVerticalOrigin(self.otf, glyph)
             bounds = self.glyphBoundingBoxes[glyphName]
             top = bounds.yMax if bounds else 0
             vmtx[glyphName] = (height, verticalOrigin - top)
@@ -673,12 +673,13 @@ class BaseOutlineCompiler(object):
         vorg.minorVersion = 0
         vorg.VOriginRecords = {}
         # Find the most frequent verticalOrigin
-        vorg_count = Counter(_getVerticalOrigin(glyph)
+        vorg_count = Counter(_getVerticalOrigin(self.otf, glyph)
                              for glyph in self.allGlyphs.values())
         vorg.defaultVertOriginY = vorg_count.most_common(1)[0][0]
         if len(vorg_count) > 1:
             for glyphName, glyph in self.allGlyphs.items():
-                vorg.VOriginRecords[glyphName] = _getVerticalOrigin(glyph)
+                vorg.VOriginRecords[glyphName] = _getVerticalOrigin(
+                    self.otf, glyph)
         vorg.numVertOriginYMetrics = len(vorg.VOriginRecords)
 
     def setupTable_vhea(self):

--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -654,8 +654,8 @@ class BaseOutlineCompiler(object):
             else:
                 boundsAdvance = (bounds.yMax - bounds.yMin)
                 # equation from the vhea spec for calculating yMaxExtent:
-                #   Max(tsb - (yMax - yMin)).
-                extent = firstSideBearing - boundsAdvance
+                #   Max(tsb + (yMax - yMin)).
+                extent = firstSideBearing + boundsAdvance
             secondSideBearing = advance - firstSideBearing - boundsAdvance
 
             firstSideBearings.append(firstSideBearing)

--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -721,8 +721,8 @@ class BaseOutlineCompiler(object):
             tops.append(top)
             bottoms.append(bottom)
         vhea.advanceHeightMax = max(heights)
-        vhea.minTopSideBearing = max(tops)
-        vhea.minBottomSideBearing = max(bottoms)
+        vhea.minTopSideBearing = min(tops) if tops else 0
+        vhea.minBottomSideBearing = min(bottoms) if bottoms else 0
         vhea.yMaxExtent = vhea.minTopSideBearing - (head.yMax - head.yMin)
         # misc
         vhea.caretSlopeRise = getAttrWithFallback(font.info, "openTypeVheaCaretSlopeRise")

--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -79,12 +79,19 @@ class BaseOutlineCompiler(object):
         """
         self.otf = TTFont(sfntVersion=self.sfntVersion)
 
-        self.vertical = False
-        for glyph in self.allGlyphs.values():
-            if (hasattr(glyph, "verticalOrigin") and
-                    glyph.verticalOrigin is not None):
-                self.vertical = True
-                break
+        # only compile vertical metrics tables if vhea metrics a defined
+        vertical_metrics = [
+            "openTypeVheaVertTypoAscender",
+            "openTypeVheaVertTypoDescender",
+            "openTypeVheaVertTypoLineGap",
+            "openTypeVheaCaretSlopeRise",
+            "openTypeVheaCaretSlopeRun",
+            "openTypeVheaCaretOffset",
+        ]
+        self.vertical = all(
+            getAttrWithFallback(self.ufo.info, metric) is not None
+            for metric in vertical_metrics
+        )
 
         # populate basic tables
         self.setupTable_head()

--- a/tests/data/TestFont-CFF.ttx
+++ b/tests/data/TestFont-CFF.ttx
@@ -442,6 +442,13 @@
     </LookupList>
   </GPOS>
 
+  <VORG>
+    <majorVersion value="1"/>
+    <minorVersion value="0"/>
+    <defaultVertOriginY value="750"/>
+    <numVertOriginYMetrics value="0"/>
+  </VORG>
+
   <hmtx>
     <mtx name=".notdef" width="500" lsb="50"/>
     <mtx name="uni0020" width="250" lsb="0"/>
@@ -458,5 +465,42 @@
     <mtx name="uni006B" width="600" lsb="66"/>
     <mtx name="uni006C" width="600" lsb="78"/>
   </hmtx>
+
+  <vhea>
+    <tableVersion value="0x00011000"/>
+    <ascent value="750"/>
+    <descent value="-250"/>
+    <lineGap value="200"/>
+    <advanceHeightMax value="1000"/>
+    <minTopSideBearing value="0"/>
+    <minBottomSideBearing value="-80"/>
+    <yMaxExtent value="1030"/>
+    <caretSlopeRise value="0"/>
+    <caretSlopeRun value="1"/>
+    <caretOffset value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <reserved4 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfVMetrics value="12"/>
+  </vhea>
+
+  <vmtx>
+    <mtx name=".notdef" height="1000" tsb="0"/>
+    <mtx name="uni0020" height="250" tsb="750"/>
+    <mtx name="uni0061" height="750" tsb="240"/>
+    <mtx name="uni0062" height="750" tsb="245"/>
+    <mtx name="uni0063" height="750" tsb="250"/>
+    <mtx name="uni0064" height="750" tsb="553"/>
+    <mtx name="uni0065" height="750" tsb="240"/>
+    <mtx name="uni0066" height="750" tsb="240"/>
+    <mtx name="uni0067" height="750" tsb="240"/>
+    <mtx name="uni0068" height="1000" tsb="93"/>
+    <mtx name="uni0069" height="750" tsb="240"/>
+    <mtx name="uni006A" height="1000" tsb="520"/>
+    <mtx name="uni006B" height="1000" tsb="240"/>
+    <mtx name="uni006C" height="1000" tsb="240"/>
+  </vmtx>
 
 </ttFont>

--- a/tests/data/TestFont-NoOverlaps-CFF.ttx
+++ b/tests/data/TestFont-NoOverlaps-CFF.ttx
@@ -444,6 +444,13 @@
     </LookupList>
   </GPOS>
 
+  <VORG>
+    <majorVersion value="1"/>
+    <minorVersion value="0"/>
+    <defaultVertOriginY value="750"/>
+    <numVertOriginYMetrics value="0"/>
+  </VORG>
+
   <hmtx>
     <mtx name=".notdef" width="500" lsb="50"/>
     <mtx name="uni0020" width="250" lsb="0"/>
@@ -460,5 +467,42 @@
     <mtx name="uni006B" width="600" lsb="66"/>
     <mtx name="uni006C" width="600" lsb="78"/>
   </hmtx>
+
+  <vhea>
+    <tableVersion value="0x00011000"/>
+    <ascent value="750"/>
+    <descent value="-250"/>
+    <lineGap value="200"/>
+    <advanceHeightMax value="1000"/>
+    <minTopSideBearing value="0"/>
+    <minBottomSideBearing value="-80"/>
+    <yMaxExtent value="1030"/>
+    <caretSlopeRise value="0"/>
+    <caretSlopeRun value="1"/>
+    <caretOffset value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <reserved4 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfVMetrics value="12"/>
+  </vhea>
+
+  <vmtx>
+    <mtx name=".notdef" height="1000" tsb="0"/>
+    <mtx name="uni0020" height="250" tsb="750"/>
+    <mtx name="uni0061" height="750" tsb="240"/>
+    <mtx name="uni0062" height="750" tsb="245"/>
+    <mtx name="uni0063" height="750" tsb="250"/>
+    <mtx name="uni0064" height="750" tsb="553"/>
+    <mtx name="uni0065" height="750" tsb="240"/>
+    <mtx name="uni0066" height="750" tsb="240"/>
+    <mtx name="uni0067" height="750" tsb="240"/>
+    <mtx name="uni0068" height="1000" tsb="93"/>
+    <mtx name="uni0069" height="750" tsb="240"/>
+    <mtx name="uni006A" height="1000" tsb="520"/>
+    <mtx name="uni006B" height="1000" tsb="240"/>
+    <mtx name="uni006C" height="1000" tsb="240"/>
+  </vmtx>
 
 </ttFont>

--- a/tests/data/TestFont-NoOverlaps-TTF.ttx
+++ b/tests/data/TestFont-NoOverlaps-TTF.ttx
@@ -537,4 +537,41 @@
     </LookupList>
   </GPOS>
 
+  <vhea>
+    <tableVersion value="0x00011000"/>
+    <ascent value="750"/>
+    <descent value="-250"/>
+    <lineGap value="200"/>
+    <advanceHeightMax value="1000"/>
+    <minTopSideBearing value="0"/>
+    <minBottomSideBearing value="-80"/>
+    <yMaxExtent value="1030"/>
+    <caretSlopeRise value="0"/>
+    <caretSlopeRun value="1"/>
+    <caretOffset value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <reserved4 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfVMetrics value="12"/>
+  </vhea>
+
+  <vmtx>
+    <mtx name=".notdef" height="1000" tsb="0"/>
+    <mtx name="uni0020" height="250" tsb="750"/>
+    <mtx name="uni0061" height="750" tsb="240"/>
+    <mtx name="uni0062" height="750" tsb="245"/>
+    <mtx name="uni0063" height="750" tsb="250"/>
+    <mtx name="uni0064" height="750" tsb="553"/>
+    <mtx name="uni0065" height="750" tsb="240"/>
+    <mtx name="uni0066" height="750" tsb="240"/>
+    <mtx name="uni0067" height="750" tsb="240"/>
+    <mtx name="uni0068" height="1000" tsb="93"/>
+    <mtx name="uni0069" height="750" tsb="240"/>
+    <mtx name="uni006A" height="1000" tsb="520"/>
+    <mtx name="uni006B" height="1000" tsb="240"/>
+    <mtx name="uni006C" height="1000" tsb="240"/>
+  </vmtx>
+
 </ttFont>

--- a/tests/data/TestFont.ttx
+++ b/tests/data/TestFont.ttx
@@ -535,4 +535,41 @@
     </LookupList>
   </GPOS>
 
+  <vhea>
+    <tableVersion value="0x00011000"/>
+    <ascent value="750"/>
+    <descent value="-250"/>
+    <lineGap value="200"/>
+    <advanceHeightMax value="1000"/>
+    <minTopSideBearing value="0"/>
+    <minBottomSideBearing value="-80"/>
+    <yMaxExtent value="1030"/>
+    <caretSlopeRise value="0"/>
+    <caretSlopeRun value="1"/>
+    <caretOffset value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <reserved4 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfVMetrics value="12"/>
+  </vhea>
+
+  <vmtx>
+    <mtx name=".notdef" height="1000" tsb="0"/>
+    <mtx name="uni0020" height="250" tsb="750"/>
+    <mtx name="uni0061" height="750" tsb="240"/>
+    <mtx name="uni0062" height="750" tsb="245"/>
+    <mtx name="uni0063" height="750" tsb="250"/>
+    <mtx name="uni0064" height="750" tsb="553"/>
+    <mtx name="uni0065" height="750" tsb="240"/>
+    <mtx name="uni0066" height="750" tsb="240"/>
+    <mtx name="uni0067" height="750" tsb="240"/>
+    <mtx name="uni0068" height="1000" tsb="93"/>
+    <mtx name="uni0069" height="750" tsb="240"/>
+    <mtx name="uni006A" height="1000" tsb="520"/>
+    <mtx name="uni006B" height="1000" tsb="240"/>
+    <mtx name="uni006C" height="1000" tsb="240"/>
+  </vmtx>
+
 </ttFont>

--- a/tests/data/TestFont.ufo/glyphs/_notdef.glif
+++ b/tests/data/TestFont.ufo/glyphs/_notdef.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name=".notdef" format="2">
-	<advance width="500"/>
+	<advance height="1000" width="500"/>
 	<outline>
 		<contour>
 			<point x="450" y="0" type="line"/>

--- a/tests/data/TestFont.ufo/glyphs/a.glif
+++ b/tests/data/TestFont.ufo/glyphs/a.glif
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="a" format="2">
 	<unicode hex="0061"/>
-	<advance width="388"/>
+	<advance height="750" width="388"/>
 	<outline>
 		<contour>
 			<point x="66" y="0" type="line"/>

--- a/tests/data/TestFont.ufo/glyphs/b.glif
+++ b/tests/data/TestFont.ufo/glyphs/b.glif
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="b" format="2">
 	<unicode hex="0062"/>
-	<advance width="410"/>
+	<advance height="750" width="410"/>
 	<outline>
 		<contour>
 			<point x="100" y="505" type="line"/>

--- a/tests/data/TestFont.ufo/glyphs/c.glif
+++ b/tests/data/TestFont.ufo/glyphs/c.glif
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="c" format="2">
 	<unicode hex="0063"/>
-	<advance width="374"/>
+	<advance height="750" width="374"/>
 	<outline>
 		<contour>
 			<point x="300" y="-10" type="curve"/>

--- a/tests/data/TestFont.ufo/glyphs/d.glif
+++ b/tests/data/TestFont.ufo/glyphs/d.glif
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="d" format="2">
 	<unicode hex="0064"/>
-	<advance width="374"/>
+	<advance height="750" width="374"/>
 	<outline>
 		<contour>
 			<point x="150.66" y="197.32" type="curve"/>

--- a/tests/data/TestFont.ufo/glyphs/e.glif
+++ b/tests/data/TestFont.ufo/glyphs/e.glif
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="e" format="2">
 	<unicode hex="0065"/>
-	<advance width="388"/>
+	<advance height="750" width="388"/>
 	<outline>
 		<contour>
 			<point x="66" y="510" type="line"/>

--- a/tests/data/TestFont.ufo/glyphs/f.glif
+++ b/tests/data/TestFont.ufo/glyphs/f.glif
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="f" format="2">
 	<unicode hex="0066"/>
-	<advance width="410"/>
+	<advance height="750" width="410"/>
 	<outline>
 		<contour>
 			<point x="66" y="510" type="line"/>

--- a/tests/data/TestFont.ufo/glyphs/g.glif
+++ b/tests/data/TestFont.ufo/glyphs/g.glif
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="g" format="2">
 	<unicode hex="0067"/>
-	<advance width="388"/>
+	<advance height="750" width="388"/>
 	<outline>
 		<component base="a"/>
 	</outline>

--- a/tests/data/TestFont.ufo/glyphs/h.glif
+++ b/tests/data/TestFont.ufo/glyphs/h.glif
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="h" format="2">
 	<unicode hex="0068"/>
-	<advance width="410"/>
+	<advance height="1000" width="410"/>
 	<outline>
 		<component base="d" xOffset="60" yOffset="460"/>
 		<component base="b"/>

--- a/tests/data/TestFont.ufo/glyphs/i.glif
+++ b/tests/data/TestFont.ufo/glyphs/i.glif
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="i" format="2">
 	<unicode hex="0069"/>
-	<advance width="600"/>
+	<advance height="750" width="600"/>
 	<outline>
 		<contour>
 			<point x="-55" y="-80" type="curve"/>

--- a/tests/data/TestFont.ufo/glyphs/j.glif
+++ b/tests/data/TestFont.ufo/glyphs/j.glif
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="j" format="2">
 	<unicode hex="006A"/>
-	<advance width="600"/>
+	<advance height="1000" width="600"/>
 	<outline>
 		<contour>
 			<point x="-55" y="-80" type="curve"/>

--- a/tests/data/TestFont.ufo/glyphs/k.glif
+++ b/tests/data/TestFont.ufo/glyphs/k.glif
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="k" format="2">
 	<unicode hex="006B"/>
-	<advance width="600"/>
+	<advance height="1000" width="600"/>
 	<outline>
 		<component base="a"/>
 		<component base="a" xOffset="100"/>

--- a/tests/data/TestFont.ufo/glyphs/l.glif
+++ b/tests/data/TestFont.ufo/glyphs/l.glif
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="l" format="2">
 	<unicode hex="006C"/>
-	<advance width="600"/>
+	<advance height="1000" width="600"/>
 	<outline>
 		<component base="a" xScale="-1" xOffset="400"/>
 		<component base="a" xOffset="100"/>

--- a/tests/data/TestFont.ufo/glyphs/space.glif
+++ b/tests/data/TestFont.ufo/glyphs/space.glif
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="space" format="2">
 	<unicode hex="0020"/>
-	<advance width="250"/>
+	<advance height="250" width="250"/>
 </glyph>


### PR DESCRIPTION
* Use hhea.ascender instead of glyph.height as fallback verticalOrigin (fixes #231)
* Compile vertical metrics tables iff vhea metrics are defined instead of when verticalOrigin is defined in some glyphs.
* Update tests that have vhea metrics defined
* Share logic for setupTable_hhea and setupTable_vhea