### PR TITLE
[outlineCompiler] don't set CID-only FontName operator in CFF TopDict

### DIFF
--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -931,7 +931,6 @@ class OutlineOTFCompiler(BaseOutlineCompiler):
         topDict.FullName = getAttrWithFallback(info, "postscriptFullName")
         topDict.FamilyName = getAttrWithFallback(info, "openTypeNamePreferredFamilyName")
         topDict.Weight = getAttrWithFallback(info, "postscriptWeightName")
-        topDict.FontName = psName
         # populate various numbers
         topDict.isFixedPitch = getAttrWithFallback(info, "postscriptIsFixedPitch")
         topDict.ItalicAngle = getAttrWithFallback(info, "italicAngle")

--- a/tests/data/TestFont-CFF.ttx
+++ b/tests/data/TestFont-CFF.ttx
@@ -229,7 +229,6 @@
       <Notice value="Trademark Some Foundry"/>
       <Copyright value="Copyright Copyright Some Foundry."/>
       <FullName value="Some Font-Regular (Postscript Full Name)"/>
-      <FontName value="SomeFont-Regular (Postscript Font Name)"/>
       <FamilyName value="Some Font (Preferred Family Name)"/>
       <Weight value="Medium"/>
       <isFixedPitch value="0"/>

--- a/tests/data/TestFont-NoOverlaps-CFF.ttx
+++ b/tests/data/TestFont-NoOverlaps-CFF.ttx
@@ -229,7 +229,6 @@
       <Notice value="Trademark Some Foundry"/>
       <Copyright value="Copyright Copyright Some Foundry."/>
       <FullName value="Some Font-Regular (Postscript Full Name)"/>
-      <FontName value="SomeFont-Regular (Postscript Font Name)"/>
       <FamilyName value="Some Font (Preferred Family Name)"/>
       <Weight value="Medium"/>
       <isFixedPitch value="0"/>


### PR DESCRIPTION
It appears that the `FontName` dict operator is only valid in the Font Dict of CID-keyed CFF fonts.
Since we emit a name-keyed CFF table, this field is redundant at best.

Even worse, on latest macOS 10.13 the presence of this operator in the CFF breaks the QuickLook preview (space-bar from Finder), and the font appears all blank -- maybe they use it to detect whether CFF is name- or CID-keyed, and then fail to render because in fact it isn't CID...

Besides, MakeOTF silently strips this when it is passed an OTF produced by fontmake.

So we can safely remove it.

Note that the postscriptName from the fontinfo.plist is still encoded in the Name INDEX structure (ttx dumps this as the 'name' attribute of the CFFFont element).

It is just the dict operator that should not be there.