### PR TITLE
os2.xAvgCharWidth: Guard against all glyphs having a zero width

### DIFF
--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -424,7 +424,11 @@ class BaseOutlineCompiler(object):
         os2.version = 0x0004
         # average glyph width
         widths = [width for width, _ in hmtx.metrics.values() if width > 0]
-        os2.xAvgCharWidth = round(sum(widths) / len(widths))
+        if widths:
+            os2.xAvgCharWidth = round(sum(widths) / len(widths))
+        else:
+            logger.warn("All glyphs have a zero width. Is this intentional?")
+            os2.xAvgCharWidth = 0
         # weight and width classes
         os2.usWeightClass = getAttrWithFallback(font.info, "openTypeOS2WeightClass")
         os2.usWidthClass = getAttrWithFallback(font.info, "openTypeOS2WidthClass")

--- a/tests/outlineCompiler_test.py
+++ b/tests/outlineCompiler_test.py
@@ -101,6 +101,12 @@ class OutlineTTFCompilerTest(unittest.TestCase):
         self.assertEqual(compiler.otf['hhea'].minRightSideBearing, 0)
         self.assertEqual(compiler.otf['hhea'].xMaxExtent, 0)
 
+    def test_os2_no_widths(self):
+        for glyph in self.ufo:
+            glyph.width = 0
+        compiler = OutlineTTFCompiler(self.ufo)
+        compiler.compile()
+        self.assertEqual(compiler.otf['OS/2'].xAvgCharWidth, 0)
 
 class OutlineOTFCompilerTest(unittest.TestCase):
 


### PR DESCRIPTION
Stumbled over this after doing `rm ...ufo/glyphs && mv ...ufo/glyphs.background.public ...ufo/glyphs` in one of our fonts and that layer had no widths set.