### PR TITLE
AppVeyor: Trigger just one build after initial PR opening

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,10 @@ environment:
       TOXENV: "py36-cov"
       TOXPYTHON: "C:\\Python36-x64\\python.exe"
 
+# Do not build feature branches with open Pull Requests after the initial 
+# opening of a PR.
+skip_branch_with_pr: true
+
 install:
   # If there is a newer build queued for the same PR, cancel this one.
   # The AppVeyor 'rollout builds' option is supposed to serve the same


### PR DESCRIPTION
Currently, pushing to a branch in the main repo and then opening a PR
about it will always trigger both a "pr" and "branch" build on AppVeyor.
This change should only trigger a build once after the PR was initially
opened.