### PR TITLE
How to handle input UFO with bad glyph names?

### DIFF
--- a/tests/featureWriters/kernFeatureWriter_test.py
+++ b/tests/featureWriters/kernFeatureWriter_test.py
@@ -10,6 +10,7 @@ import logging
 
 from ufo2ft.featureCompiler import parseLayoutFeatures
 from ufo2ft.featureWriters import KernFeatureWriter, ast
+from ufo2ft.errors import InvalidFontData
 
 import pytest
 from . import FeatureWriterTest
@@ -721,6 +722,15 @@ class KernFeatureWriterTest(FeatureWriterTest):
             } kern;
             """
         )
+
+    def test_error_on_bad_glyph_name(self, FontClass):
+        # One glyph has an invalid glyph name (in fea syntax): "V,"
+        glyphs = {"A": ord('A'), "V,": ord("V")}
+        kerning = {("A", "V,"): -40}
+        features = "languagesystem latn dflt;"
+        ufo = makeUFO(FontClass, glyphs, kerning=kerning, features=features)
+        with pytest.raises(InvalidFontData):
+            generated = self.writeFeatures(ufo)
 
 
 if __name__ == "__main__":

--- a/tests/featureWriters/markFeatureWriter_test.py
+++ b/tests/featureWriters/markFeatureWriter_test.py
@@ -13,6 +13,7 @@ from ufo2ft.featureWriters.markFeatureWriter import (
     parseAnchorName,
 )
 from ufo2ft.featureCompiler import parseLayoutFeatures
+from ufo2ft.errors import InvalidFontData
 
 import pytest
 from . import FeatureWriterTest
@@ -578,6 +579,14 @@ class MarkFeatureWriterTest(FeatureWriterTest):
             } mkmk;
             """
         )
+
+    def test_error_on_bad_glyph_name(self, testufo):
+        # Add a glyph with an invalid name to the test UFO: "f_i,"
+        testufo.newGlyph("a,").appendAnchor({"name": "top", "x": 100, "y": 200})
+        writer = MarkFeatureWriter()
+        feaFile = ast.FeatureFile()
+        with pytest.raises(InvalidFontData):
+            writer.write(testufo, feaFile)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When someone tries to compile with fontmake a UFO that has an invalid glyph name (in this case it was "G," with a literal comma in the name), the bad glyph name goes verbatim into the output feature code and fontmake complains about the syntax being wrong. When trying to understand the problem, it's a bit confusing because the original feature only has valid syntax, and the syntax error lies in what ufo2ft writes out.

I have added tests that cover this bug. What do you think we should do?

1. Not care: the bad naming was obviously a mistake, and it doesn't happen often enough to warrant a proper error message
2. Make ufo2ft raise when glyph names are wrong: in my opinion ufo2ft should always output compilable feature code, or raise if that's not possible.
3. @moyogo suggests that this should not be an issue in the first place, and ufo2ft/fontmake should rename glyphs to production names on the fly and don't care about crazy glyph names