### PR TITLE
handle duplicate production names, with invalid PS chars, or too long (> 63 chars)

### DIFF
--- a/Lib/ufo2ft/__init__.py
+++ b/Lib/ufo2ft/__init__.py
@@ -93,7 +93,7 @@ def compileOTF(
         featureCompilerClass=featureCompilerClass,
     )
 
-    postProcessor = PostProcessor(otf, ufo)
+    postProcessor = PostProcessor(otf, ufo, glyphSet=glyphSet)
     otf = postProcessor.process(useProductionNames, optimizeCFF)
 
     return otf


### PR DESCRIPTION
This patch ensures that we never end up writing duplicate postscript glyph names in the post/CFF tables.
FontTools will crash if we set `TTFont.setGlyphOrder()` to a list containing duplicate glyph names, so need to avoid this.
Also, following AGL specification, we strip any characters that is not in the safe postscript character set `[A-Za-z0-9_.]`, e.g. like hyphens sometimes used in Glyphs.app.
And we print a warning if a glyph name exceeds 63 characters in length (see https://github.com/adobe-type-tools/agl-specification/issues/2).