### PR TITLE
Building production names: ignore glyph names not in source

### DIFF
--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -1166,21 +1166,9 @@ class StubGlyph(object):
             return 1
         return 0
 
-    def _get_leftMargin(self):
-        if self.bounds is None:
-            return 0
-        return self.bounds[0]
-
-    leftMargin = property(_get_leftMargin)
-
-    def _get_rightMargin(self):
-        bounds = self.bounds
-        if bounds is None:
-            return 0
-        xMin, yMin, xMax, yMax = bounds
-        return self.width - bounds[2]
-
-    rightMargin = property(_get_rightMargin)
+    @property
+    def height(self):
+        return self.ascender - self.descender
 
     def draw(self, pen):
         pass

--- a/Lib/ufo2ft/postProcessor.py
+++ b/Lib/ufo2ft/postProcessor.py
@@ -88,6 +88,10 @@ class PostProcessor(object):
         seen = {}
         rename_map = {}
         for name in self.otf.getGlyphOrder():
+            # Ignore glyphs that aren't in the source, as they are usually generated 
+            # and we lack information about them.
+            if name not in self.glyphSet:
+                continue
             prod_name = self._build_production_name(self.glyphSet[name])
 
             # strip invalid characters not allowed in postscript glyph names

--- a/tests/outlineCompiler_test.py
+++ b/tests/outlineCompiler_test.py
@@ -615,6 +615,21 @@ class NamesTest(object):
         result = compileTTF(testufo)
         assert result.getGlyphOrder() == expected
 
+    def test_postprocess_production_names_no_notdef(self, testufo):
+        import ufo2ft
+
+        del testufo[".notdef"]
+        assert ".notdef" not in testufo
+        result = compileTTF(testufo, useProductionNames=False)
+        assert ".notdef" in result.getGlyphOrder()
+
+        pp = ufo2ft.postProcessor.PostProcessor(result, testufo, glyphSet=None)
+        try:
+            f = pp.process(useProductionNames=True)
+        except Exception as e:
+            pytest.xfail("Unexpected exception: " + str(e))
+        assert ".notdef" in f.getGlyphOrder()
+
     CUSTOM_POSTSCRIPT_NAMES = {
         ".notdef": ".notdef",
         "space": "foo",


### PR DESCRIPTION
This makes building production names work if the source is e.g. missing `.notdef` and ufo2ft synthesized it.

Also remove unused and non-functional StubGlyph.(left|right)Margin.