### PR TITLE
have existing optimizeCFF option also control charstring specializer

### DIFF
--- a/Lib/ufo2ft/__init__.py
+++ b/Lib/ufo2ft/__init__.py
@@ -45,7 +45,8 @@ def compileOTF(
 
     *removeOverlaps* performs a union operation on all the glyphs' contours.
 
-    *optimizeCFF* sets whether the CFF table should be subroutinized.
+    *optimizeCFF* sets whether the CFF charstrings should be specialized
+      and subroutinized.
 
     *roundTolerance* (float) controls the rounding of point coordinates.
       It is defined as the maximum absolute difference between the original

--- a/Lib/ufo2ft/__init__.py
+++ b/Lib/ufo2ft/__init__.py
@@ -85,6 +85,7 @@ def compileOTF(
         glyphSet=glyphSet,
         glyphOrder=glyphOrder,
         roundTolerance=roundTolerance,
+        optimizeCFF=optimizeCFF,
     )
     otf = outlineCompiler.compile()
 

--- a/Lib/ufo2ft/featureCompiler.py
+++ b/Lib/ufo2ft/featureCompiler.py
@@ -265,7 +265,7 @@ class FeatureCompiler(BaseFeatureCompiler):
 
 # defcon lists UFO data filenames using platform-specific path separators.
 # TODO change it to always return UNIX forward slashes
-MTI_FEATURES_PREFIX = "com.github.googlei18n.ufo2ft.mtiFeatures" + os.path.sep
+MTI_FEATURES_PREFIX = "com.github.googlei18n.ufo2ft.mtiFeatures/"
 
 
 class MtiFeatureCompiler(BaseFeatureCompiler):

--- a/Lib/ufo2ft/featureCompiler.py
+++ b/Lib/ufo2ft/featureCompiler.py
@@ -263,9 +263,7 @@ class FeatureCompiler(BaseFeatureCompiler):
             raise
 
 
-# defcon lists UFO data filenames using platform-specific path separators.
-# TODO change it to always return UNIX forward slashes
-MTI_FEATURES_PREFIX = "com.github.googlei18n.ufo2ft.mtiFeatures/"
+MTI_FEATURES_PREFIX = "com.github.googlei18n.ufo2ft.mtiFeatures"
 
 
 class MtiFeatureCompiler(BaseFeatureCompiler):
@@ -273,12 +271,22 @@ class MtiFeatureCompiler(BaseFeatureCompiler):
     fontTools.mtiLib.
     """
 
+    def __init__(self, ufo, ttFont=None, glyphSet=None, **kwargs):
+        super(MtiFeatureCompiler, self).__init__(
+            ufo, ttFont=ttFont, glyphSet=glyphSet, **kwargs
+        )
+        # defcon (as of 0.5.3) lists UFO data filenames using platform-specific
+        # path separators, whereas the new fontTools.ufoLib uses `fs` module
+        # internally which always requires UNIX forward slashes on all platforms
+        sep = "/" if hasattr(ufo, "fs") else os.path.sep
+        self._mti_features_prefix = MTI_FEATURES_PREFIX + sep
+
     def setupFeatures(self):
         ufo = self.ufo
         features = {}
-        prefixLength = len(MTI_FEATURES_PREFIX)
+        prefixLength = len(self._mti_features_prefix)
         for fn in ufo.data.fileNames:
-            if fn.startswith(MTI_FEATURES_PREFIX) and fn.endswith(".mti"):
+            if fn.startswith(self._mti_features_prefix) and fn.endswith(".mti"):
                 content = tounicode(ufo.data[fn], encoding="utf-8")
                 features[fn[prefixLength:-4]] = content
         self.mtiFeatures = features

--- a/Lib/ufo2ft/outlineCompiler.py
+++ b/Lib/ufo2ft/outlineCompiler.py
@@ -821,8 +821,14 @@ class OutlineOTFCompiler(BaseOutlineCompiler):
 
     sfntVersion = "OTTO"
 
-    def __init__(self, font, glyphSet=None, glyphOrder=None,
-                 roundTolerance=None):
+    def __init__(
+        self,
+        font,
+        glyphSet=None,
+        glyphOrder=None,
+        roundTolerance=None,
+        optimizeCFF=True,
+    ):
         if roundTolerance is not None:
             self.roundTolerance = float(roundTolerance)
         else:
@@ -830,6 +836,7 @@ class OutlineOTFCompiler(BaseOutlineCompiler):
             self.roundTolerance = 0.5
         super(OutlineOTFCompiler, self).__init__(
             font, glyphSet=glyphSet, glyphOrder=glyphOrder)
+        self.optimizeCFF = optimizeCFF
 
     def makeGlyphsBoundingBoxes(self):
         """
@@ -895,7 +902,9 @@ class OutlineOTFCompiler(BaseOutlineCompiler):
         pen = T2CharStringPen(width, self.allGlyphs,
                               roundTolerance=self.roundTolerance)
         glyph.draw(pen)
-        charString = pen.getCharString(private, globalSubrs)
+        charString = pen.getCharString(
+            private, globalSubrs, optimize=self.optimizeCFF
+        )
         return charString
 
     def setupTable_maxp(self):

--- a/tests/data/TestFont-NoOptimize-CFF.ttx
+++ b/tests/data/TestFont-NoOptimize-CFF.ttx
@@ -1,0 +1,525 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="OTTO" ttLibVersion="3.31">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="uni0020"/>
+    <GlyphID id="2" name="uni0061"/>
+    <GlyphID id="3" name="uni0062"/>
+    <GlyphID id="4" name="uni0063"/>
+    <GlyphID id="5" name="uni0064"/>
+    <GlyphID id="6" name="uni0065"/>
+    <GlyphID id="7" name="uni0066"/>
+    <GlyphID id="8" name="uni0067"/>
+    <GlyphID id="9" name="uni0068"/>
+    <GlyphID id="10" name="uni0069"/>
+    <GlyphID id="11" name="uni006A"/>
+    <GlyphID id="12" name="uni006B"/>
+    <GlyphID id="13" name="uni006C"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="1.0"/>
+    <checkSumAdjustment value="0x12345678"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Fri Feb 17 17:17:17 2017"/>
+    <modified value="Sun Feb 18 18:18:18 2018"/>
+    <xMin value="-55"/>
+    <yMin value="-280"/>
+    <xMax value="454"/>
+    <yMax value="750"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="10"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="750"/>
+    <descent value="-250"/>
+    <lineGap value="200"/>
+    <advanceWidthMax value="600"/>
+    <minLeftSideBearing value="-55"/>
+    <minRightSideBearing value="-66"/>
+    <xMaxExtent value="454"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="11"/>
+  </hhea>
+
+  <maxp>
+    <tableVersion value="0x5000"/>
+    <numGlyphs value="14"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="4"/>
+    <xAvgCharWidth value="449"/>
+    <usWeightClass value="500"/>
+    <usWidthClass value="5"/>
+    <fsType value="00000000 00000000"/>
+    <ySubscriptXSize value="200"/>
+    <ySubscriptYSize value="400"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="-100"/>
+    <ySuperscriptXSize value="200"/>
+    <ySuperscriptYSize value="400"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="200"/>
+    <yStrikeoutSize value="20"/>
+    <yStrikeoutPosition value="300"/>
+    <sFamilyClass value="257"/>
+    <panose>
+      <bFamilyType value="0"/>
+      <bSerifStyle value="1"/>
+      <bWeight value="2"/>
+      <bProportion value="3"/>
+      <bContrast value="4"/>
+      <bStrokeVariation value="5"/>
+      <bArmStyle value="6"/>
+      <bLetterForm value="7"/>
+      <bMidline value="8"/>
+      <bXHeight value="9"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00000000 00000011"/>
+    <ulUnicodeRange2 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="SOME"/>
+    <fsSelection value="00000000 01001000"/>
+    <usFirstCharIndex value="32"/>
+    <usLastCharIndex value="108"/>
+    <sTypoAscender value="750"/>
+    <sTypoDescender value="-250"/>
+    <sTypoLineGap value="200"/>
+    <usWinAscent value="750"/>
+    <usWinDescent value="250"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000011"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="500"/>
+    <sCapHeight value="750"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="2"/>
+  </OS_2>
+
+  <name>
+    <namerecord nameID="3" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Unique Font Identifier
+    </namerecord>
+    <namerecord nameID="0" platformID="3" platEncID="1" langID="0x409">
+      Copyright © Some Foundry.
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      Some Font Regular (Style Map Family Name)
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      OpenType name Table Unique ID
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      Some Font (Preferred Family Name) Regular (Preferred Subfamily Name)
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      OpenType name Table Version
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      SomeFont-Regular Postscript Font Name
+    </namerecord>
+    <namerecord nameID="7" platformID="3" platEncID="1" langID="0x409">
+      Trademark Some Foundry
+    </namerecord>
+    <namerecord nameID="8" platformID="3" platEncID="1" langID="0x409">
+      Some Foundry (Manufacturer Name)
+    </namerecord>
+    <namerecord nameID="9" platformID="3" platEncID="1" langID="0x409">
+      Some Designer
+    </namerecord>
+    <namerecord nameID="10" platformID="3" platEncID="1" langID="0x409">
+      Some Font by Some Designer for Some Foundry.
+    </namerecord>
+    <namerecord nameID="11" platformID="3" platEncID="1" langID="0x409">
+      http://somefoundry.com
+    </namerecord>
+    <namerecord nameID="12" platformID="3" platEncID="1" langID="0x409">
+      http://somedesigner.com
+    </namerecord>
+    <namerecord nameID="13" platformID="3" platEncID="1" langID="0x409">
+      License info for Some Foundry.
+    </namerecord>
+    <namerecord nameID="14" platformID="3" platEncID="1" langID="0x409">
+      http://somefoundry.com/license
+    </namerecord>
+    <namerecord nameID="16" platformID="3" platEncID="1" langID="0x409">
+      Some Font (Preferred Family Name)
+    </namerecord>
+    <namerecord nameID="17" platformID="3" platEncID="1" langID="0x409">
+      Regular (Preferred Subfamily Name)
+    </namerecord>
+  </name>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+      <map code="0x20" name="uni0020"/><!-- SPACE -->
+      <map code="0x61" name="uni0061"/><!-- LATIN SMALL LETTER A -->
+      <map code="0x62" name="uni0062"/><!-- LATIN SMALL LETTER B -->
+      <map code="0x63" name="uni0063"/><!-- LATIN SMALL LETTER C -->
+      <map code="0x64" name="uni0064"/><!-- LATIN SMALL LETTER D -->
+      <map code="0x65" name="uni0065"/><!-- LATIN SMALL LETTER E -->
+      <map code="0x66" name="uni0066"/><!-- LATIN SMALL LETTER F -->
+      <map code="0x67" name="uni0067"/><!-- LATIN SMALL LETTER G -->
+      <map code="0x68" name="uni0068"/><!-- LATIN SMALL LETTER H -->
+      <map code="0x69" name="uni0069"/><!-- LATIN SMALL LETTER I -->
+      <map code="0x6a" name="uni006A"/><!-- LATIN SMALL LETTER J -->
+      <map code="0x6b" name="uni006B"/><!-- LATIN SMALL LETTER K -->
+      <map code="0x6c" name="uni006C"/><!-- LATIN SMALL LETTER L -->
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+      <map code="0x20" name="uni0020"/><!-- SPACE -->
+      <map code="0x61" name="uni0061"/><!-- LATIN SMALL LETTER A -->
+      <map code="0x62" name="uni0062"/><!-- LATIN SMALL LETTER B -->
+      <map code="0x63" name="uni0063"/><!-- LATIN SMALL LETTER C -->
+      <map code="0x64" name="uni0064"/><!-- LATIN SMALL LETTER D -->
+      <map code="0x65" name="uni0065"/><!-- LATIN SMALL LETTER E -->
+      <map code="0x66" name="uni0066"/><!-- LATIN SMALL LETTER F -->
+      <map code="0x67" name="uni0067"/><!-- LATIN SMALL LETTER G -->
+      <map code="0x68" name="uni0068"/><!-- LATIN SMALL LETTER H -->
+      <map code="0x69" name="uni0069"/><!-- LATIN SMALL LETTER I -->
+      <map code="0x6a" name="uni006A"/><!-- LATIN SMALL LETTER J -->
+      <map code="0x6b" name="uni006B"/><!-- LATIN SMALL LETTER K -->
+      <map code="0x6c" name="uni006C"/><!-- LATIN SMALL LETTER L -->
+    </cmap_format_4>
+  </cmap>
+
+  <post>
+    <formatType value="3.0"/>
+    <italicAngle value="-12.5"/>
+    <underlinePosition value="-200"/>
+    <underlineThickness value="20"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+  </post>
+
+  <CFF>
+    <major value="1"/>
+    <minor value="0"/>
+    <CFFFont name="SomeFont-Regular (Postscript Font Name)">
+      <version value="1.0"/>
+      <Notice value="Trademark Some Foundry"/>
+      <Copyright value="Copyright Copyright Some Foundry."/>
+      <FullName value="Some Font-Regular (Postscript Full Name)"/>
+      <FamilyName value="Some Font (Preferred Family Name)"/>
+      <Weight value="Medium"/>
+      <isFixedPitch value="0"/>
+      <ItalicAngle value="-12.5"/>
+      <UnderlinePosition value="-200"/>
+      <UnderlineThickness value="20"/>
+      <PaintType value="0"/>
+      <CharstringType value="2"/>
+      <FontMatrix value="0.001 0 0 0.001 0 0"/>
+      <FontBBox value="-55 -280 454 750"/>
+      <StrokeWidth value="0"/>
+      <!-- charset is dumped separately as the 'GlyphOrder' element -->
+      <Encoding name="StandardEncoding"/>
+      <Private>
+        <BlueValues value="500 510"/>
+        <OtherBlues value="-250 -260"/>
+        <FamilyBlues value="500 510"/>
+        <FamilyOtherBlues value="-250 -260"/>
+        <BlueScale value="0.039625"/>
+        <BlueShift value="7"/>
+        <BlueFuzz value="1"/>
+        <StdHW value="100"/>
+        <StdVW value="80"/>
+        <StemSnapH value="100 120"/>
+        <StemSnapV value="80 90"/>
+        <ForceBold value="1"/>
+        <LanguageGroup value="0"/>
+        <ExpansionFactor value="0.06"/>
+        <initialRandomSeed value="0"/>
+        <defaultWidthX value="400"/>
+        <nominalWidthX value="400"/>
+      </Private>
+      <CharStrings>
+        <CharString name=".notdef">
+          100 450 0 rmoveto
+          0 750 rlineto
+          -400 0 rlineto
+          0 -750 rlineto
+          350 50 rmoveto
+          -300 0 rlineto
+          0 650 rlineto
+          300 0 rlineto
+          endchar
+        </CharString>
+        <CharString name="uni0020">
+          -150 endchar
+        </CharString>
+        <CharString name="uni0061">
+          -12 66 0 rmoveto
+          256 0 rlineto
+          -128 510 rlineto
+          endchar
+        </CharString>
+        <CharString name="uni0062">
+          10 100 505 rmoveto
+          0 -510 rlineto
+          210 0 rlineto
+          0 510 rlineto
+          endchar
+        </CharString>
+        <CharString name="uni0063">
+          -26 300 -10 rmoveto
+          0 510 rlineto
+          -150 0 -50 -50 0 -205 rrcurveto
+          0 -205 50 -50 150 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="uni0064">
+          -26 151 197 rmoveto
+          -34 0 -27 -27 0 -33 rrcurveto
+          0 -33 27 -27 34 0 rrcurveto
+          33 0 27 27 0 33 rrcurveto
+          0 33 -27 27 -33 0 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="uni0065">
+          -12 66 510 rmoveto
+          128 -435 rlineto
+          128 435 rlineto
+          -377 -487 rmoveto
+          509 0 rlineto
+          0 150 -50 50 -205 0 rrcurveto
+          -204 0 -50 -50 0 -150 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="uni0066">
+          10 66 510 rmoveto
+          256 0 rlineto
+          -128 -435 rlineto
+          -249 -52 rmoveto
+          509 0 rlineto
+          0 150 -50 50 -205 0 rrcurveto
+          -204 0 -50 -50 0 -150 rrcurveto
+          endchar
+        </CharString>
+        <CharString name="uni0067">
+          -12 66 0 rmoveto
+          256 0 rlineto
+          -128 510 rlineto
+          endchar
+        </CharString>
+        <CharString name="uni0068">
+          10 211 657 rmoveto
+          -34 0 -27 -27 0 -33 rrcurveto
+          0 -33 27 -27 34 0 rrcurveto
+          33 0 27 27 0 33 rrcurveto
+          0 33 -27 27 -33 0 rrcurveto
+          -111 -152 rmoveto
+          0 -510 rlineto
+          210 0 rlineto
+          0 510 rlineto
+          endchar
+        </CharString>
+        <CharString name="uni0069">
+          200 -55 -80 rmoveto
+          509 0 rlineto
+          0 149 -50 50 -205 0 rrcurveto
+          -204 0 -50 -50 0 -149 rrcurveto
+          121 80 rmoveto
+          256 0 rlineto
+          -128 510 rlineto
+          endchar
+        </CharString>
+        <CharString name="uni006A">
+          200 -55 -80 rmoveto
+          509 0 rlineto
+          0 149 -50 50 -205 0 rrcurveto
+          -204 0 -50 -50 0 -149 rrcurveto
+          121 310 rmoveto
+          128 -510 rlineto
+          128 510 rlineto
+          endchar
+        </CharString>
+        <CharString name="uni006B">
+          200 66 0 rmoveto
+          256 0 rlineto
+          -128 510 rlineto
+          -28 -510 rmoveto
+          256 0 rlineto
+          -128 510 rlineto
+          endchar
+        </CharString>
+        <CharString name="uni006C">
+          200 334 0 rmoveto
+          -128 510 rlineto
+          -128 -510 rlineto
+          88 0 rmoveto
+          256 0 rlineto
+          -128 510 rlineto
+          endchar
+        </CharString>
+      </CharStrings>
+    </CFFFont>
+
+    <GlobalSubrs>
+      <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
+    </GlobalSubrs>
+  </CFF>
+
+  <CUST raw="True">
+    <hexdata>
+      0001beef   
+    </hexdata>
+  </CUST>
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="kern"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="2"/>
+        <LookupFlag value="8"/>
+        <!-- SubTableCount=1 -->
+        <PairPos index="0" Format="1">
+          <Coverage Format="1">
+            <Glyph value="uni0061"/>
+            <Glyph value="uni0062"/>
+          </Coverage>
+          <ValueFormat1 value="4"/>
+          <ValueFormat2 value="0"/>
+          <!-- PairSetCount=2 -->
+          <PairSet index="0">
+            <!-- PairValueCount=3 -->
+            <PairValueRecord index="0">
+              <SecondGlyph value="uni0020"/>
+              <Value1 XAdvance="1"/>
+            </PairValueRecord>
+            <PairValueRecord index="1">
+              <SecondGlyph value="uni0061"/>
+              <Value1 XAdvance="5"/>
+            </PairValueRecord>
+            <PairValueRecord index="2">
+              <SecondGlyph value="uni0062"/>
+              <Value1 XAdvance="-10"/>
+            </PairValueRecord>
+          </PairSet>
+          <PairSet index="1">
+            <!-- PairValueCount=1 -->
+            <PairValueRecord index="0">
+              <SecondGlyph value="uni0061"/>
+              <Value1 XAdvance="-7"/>
+            </PairValueRecord>
+          </PairSet>
+        </PairPos>
+      </Lookup>
+    </LookupList>
+  </GPOS>
+
+  <VORG>
+    <majorVersion value="1"/>
+    <minorVersion value="0"/>
+    <defaultVertOriginY value="750"/>
+    <numVertOriginYMetrics value="0"/>
+  </VORG>
+
+  <hmtx>
+    <mtx name=".notdef" width="500" lsb="50"/>
+    <mtx name="uni0020" width="250" lsb="0"/>
+    <mtx name="uni0061" width="388" lsb="66"/>
+    <mtx name="uni0062" width="410" lsb="100"/>
+    <mtx name="uni0063" width="374" lsb="100"/>
+    <mtx name="uni0064" width="374" lsb="90"/>
+    <mtx name="uni0065" width="388" lsb="-55"/>
+    <mtx name="uni0066" width="410" lsb="-55"/>
+    <mtx name="uni0067" width="388" lsb="66"/>
+    <mtx name="uni0068" width="410" lsb="100"/>
+    <mtx name="uni0069" width="600" lsb="-55"/>
+    <mtx name="uni006A" width="600" lsb="-55"/>
+    <mtx name="uni006B" width="600" lsb="66"/>
+    <mtx name="uni006C" width="600" lsb="78"/>
+  </hmtx>
+
+  <vhea>
+    <tableVersion value="0x00011000"/>
+    <ascent value="750"/>
+    <descent value="-250"/>
+    <lineGap value="200"/>
+    <advanceHeightMax value="1000"/>
+    <minTopSideBearing value="0"/>
+    <minBottomSideBearing value="-80"/>
+    <yMaxExtent value="1030"/>
+    <caretSlopeRise value="0"/>
+    <caretSlopeRun value="1"/>
+    <caretOffset value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <reserved4 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfVMetrics value="12"/>
+  </vhea>
+
+  <vmtx>
+    <mtx name=".notdef" height="1000" tsb="0"/>
+    <mtx name="uni0020" height="250" tsb="750"/>
+    <mtx name="uni0061" height="750" tsb="240"/>
+    <mtx name="uni0062" height="750" tsb="245"/>
+    <mtx name="uni0063" height="750" tsb="250"/>
+    <mtx name="uni0064" height="750" tsb="553"/>
+    <mtx name="uni0065" height="750" tsb="240"/>
+    <mtx name="uni0066" height="750" tsb="240"/>
+    <mtx name="uni0067" height="750" tsb="240"/>
+    <mtx name="uni0068" height="1000" tsb="93"/>
+    <mtx name="uni0069" height="750" tsb="240"/>
+    <mtx name="uni006A" height="1000" tsb="520"/>
+    <mtx name="uni006B" height="1000" tsb="240"/>
+    <mtx name="uni006C" height="1000" tsb="240"/>
+  </vmtx>
+
+</ttFont>

--- a/tests/data/TestFont-Specialized-CFF.ttx
+++ b/tests/data/TestFont-Specialized-CFF.ttx
@@ -1,0 +1,503 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont sfntVersion="OTTO" ttLibVersion="3.31">
+
+  <GlyphOrder>
+    <!-- The 'id' attribute is only for humans; it is ignored when parsed. -->
+    <GlyphID id="0" name=".notdef"/>
+    <GlyphID id="1" name="uni0020"/>
+    <GlyphID id="2" name="uni0061"/>
+    <GlyphID id="3" name="uni0062"/>
+    <GlyphID id="4" name="uni0063"/>
+    <GlyphID id="5" name="uni0064"/>
+    <GlyphID id="6" name="uni0065"/>
+    <GlyphID id="7" name="uni0066"/>
+    <GlyphID id="8" name="uni0067"/>
+    <GlyphID id="9" name="uni0068"/>
+    <GlyphID id="10" name="uni0069"/>
+    <GlyphID id="11" name="uni006A"/>
+    <GlyphID id="12" name="uni006B"/>
+    <GlyphID id="13" name="uni006C"/>
+  </GlyphOrder>
+
+  <head>
+    <!-- Most of this table will be recalculated by the compiler -->
+    <tableVersion value="1.0"/>
+    <fontRevision value="1.0"/>
+    <checkSumAdjustment value="0x12345678"/>
+    <magicNumber value="0x5f0f3cf5"/>
+    <flags value="00000000 00000011"/>
+    <unitsPerEm value="1000"/>
+    <created value="Fri Feb 17 17:17:17 2017"/>
+    <modified value="Sun Feb 18 18:18:18 2018"/>
+    <xMin value="-55"/>
+    <yMin value="-280"/>
+    <xMax value="454"/>
+    <yMax value="750"/>
+    <macStyle value="00000000 00000000"/>
+    <lowestRecPPEM value="10"/>
+    <fontDirectionHint value="2"/>
+    <indexToLocFormat value="0"/>
+    <glyphDataFormat value="0"/>
+  </head>
+
+  <hhea>
+    <tableVersion value="0x00010000"/>
+    <ascent value="750"/>
+    <descent value="-250"/>
+    <lineGap value="200"/>
+    <advanceWidthMax value="600"/>
+    <minLeftSideBearing value="-55"/>
+    <minRightSideBearing value="-66"/>
+    <xMaxExtent value="454"/>
+    <caretSlopeRise value="1"/>
+    <caretSlopeRun value="0"/>
+    <caretOffset value="0"/>
+    <reserved0 value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfHMetrics value="11"/>
+  </hhea>
+
+  <maxp>
+    <tableVersion value="0x5000"/>
+    <numGlyphs value="14"/>
+  </maxp>
+
+  <OS_2>
+    <!-- The fields 'usFirstCharIndex' and 'usLastCharIndex'
+         will be recalculated by the compiler -->
+    <version value="4"/>
+    <xAvgCharWidth value="449"/>
+    <usWeightClass value="500"/>
+    <usWidthClass value="5"/>
+    <fsType value="00000000 00000000"/>
+    <ySubscriptXSize value="200"/>
+    <ySubscriptYSize value="400"/>
+    <ySubscriptXOffset value="0"/>
+    <ySubscriptYOffset value="-100"/>
+    <ySuperscriptXSize value="200"/>
+    <ySuperscriptYSize value="400"/>
+    <ySuperscriptXOffset value="0"/>
+    <ySuperscriptYOffset value="200"/>
+    <yStrikeoutSize value="20"/>
+    <yStrikeoutPosition value="300"/>
+    <sFamilyClass value="257"/>
+    <panose>
+      <bFamilyType value="0"/>
+      <bSerifStyle value="1"/>
+      <bWeight value="2"/>
+      <bProportion value="3"/>
+      <bContrast value="4"/>
+      <bStrokeVariation value="5"/>
+      <bArmStyle value="6"/>
+      <bLetterForm value="7"/>
+      <bMidline value="8"/>
+      <bXHeight value="9"/>
+    </panose>
+    <ulUnicodeRange1 value="00000000 00000000 00000000 00000011"/>
+    <ulUnicodeRange2 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange3 value="00000000 00000000 00000000 00000000"/>
+    <ulUnicodeRange4 value="00000000 00000000 00000000 00000000"/>
+    <achVendID value="SOME"/>
+    <fsSelection value="00000000 01001000"/>
+    <usFirstCharIndex value="32"/>
+    <usLastCharIndex value="108"/>
+    <sTypoAscender value="750"/>
+    <sTypoDescender value="-250"/>
+    <sTypoLineGap value="200"/>
+    <usWinAscent value="750"/>
+    <usWinDescent value="250"/>
+    <ulCodePageRange1 value="00000000 00000000 00000000 00000011"/>
+    <ulCodePageRange2 value="00000000 00000000 00000000 00000000"/>
+    <sxHeight value="500"/>
+    <sCapHeight value="750"/>
+    <usDefaultChar value="0"/>
+    <usBreakChar value="32"/>
+    <usMaxContext value="2"/>
+  </OS_2>
+
+  <name>
+    <namerecord nameID="3" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      Unique Font Identifier
+    </namerecord>
+    <namerecord nameID="0" platformID="3" platEncID="1" langID="0x409">
+      Copyright © Some Foundry.
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      Some Font Regular (Style Map Family Name)
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Regular
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      OpenType name Table Unique ID
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      Some Font (Preferred Family Name) Regular (Preferred Subfamily Name)
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      OpenType name Table Version
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      SomeFont-Regular Postscript Font Name
+    </namerecord>
+    <namerecord nameID="7" platformID="3" platEncID="1" langID="0x409">
+      Trademark Some Foundry
+    </namerecord>
+    <namerecord nameID="8" platformID="3" platEncID="1" langID="0x409">
+      Some Foundry (Manufacturer Name)
+    </namerecord>
+    <namerecord nameID="9" platformID="3" platEncID="1" langID="0x409">
+      Some Designer
+    </namerecord>
+    <namerecord nameID="10" platformID="3" platEncID="1" langID="0x409">
+      Some Font by Some Designer for Some Foundry.
+    </namerecord>
+    <namerecord nameID="11" platformID="3" platEncID="1" langID="0x409">
+      http://somefoundry.com
+    </namerecord>
+    <namerecord nameID="12" platformID="3" platEncID="1" langID="0x409">
+      http://somedesigner.com
+    </namerecord>
+    <namerecord nameID="13" platformID="3" platEncID="1" langID="0x409">
+      License info for Some Foundry.
+    </namerecord>
+    <namerecord nameID="14" platformID="3" platEncID="1" langID="0x409">
+      http://somefoundry.com/license
+    </namerecord>
+    <namerecord nameID="16" platformID="3" platEncID="1" langID="0x409">
+      Some Font (Preferred Family Name)
+    </namerecord>
+    <namerecord nameID="17" platformID="3" platEncID="1" langID="0x409">
+      Regular (Preferred Subfamily Name)
+    </namerecord>
+  </name>
+
+  <cmap>
+    <tableVersion version="0"/>
+    <cmap_format_4 platformID="0" platEncID="3" language="0">
+      <map code="0x20" name="uni0020"/><!-- SPACE -->
+      <map code="0x61" name="uni0061"/><!-- LATIN SMALL LETTER A -->
+      <map code="0x62" name="uni0062"/><!-- LATIN SMALL LETTER B -->
+      <map code="0x63" name="uni0063"/><!-- LATIN SMALL LETTER C -->
+      <map code="0x64" name="uni0064"/><!-- LATIN SMALL LETTER D -->
+      <map code="0x65" name="uni0065"/><!-- LATIN SMALL LETTER E -->
+      <map code="0x66" name="uni0066"/><!-- LATIN SMALL LETTER F -->
+      <map code="0x67" name="uni0067"/><!-- LATIN SMALL LETTER G -->
+      <map code="0x68" name="uni0068"/><!-- LATIN SMALL LETTER H -->
+      <map code="0x69" name="uni0069"/><!-- LATIN SMALL LETTER I -->
+      <map code="0x6a" name="uni006A"/><!-- LATIN SMALL LETTER J -->
+      <map code="0x6b" name="uni006B"/><!-- LATIN SMALL LETTER K -->
+      <map code="0x6c" name="uni006C"/><!-- LATIN SMALL LETTER L -->
+    </cmap_format_4>
+    <cmap_format_4 platformID="3" platEncID="1" language="0">
+      <map code="0x20" name="uni0020"/><!-- SPACE -->
+      <map code="0x61" name="uni0061"/><!-- LATIN SMALL LETTER A -->
+      <map code="0x62" name="uni0062"/><!-- LATIN SMALL LETTER B -->
+      <map code="0x63" name="uni0063"/><!-- LATIN SMALL LETTER C -->
+      <map code="0x64" name="uni0064"/><!-- LATIN SMALL LETTER D -->
+      <map code="0x65" name="uni0065"/><!-- LATIN SMALL LETTER E -->
+      <map code="0x66" name="uni0066"/><!-- LATIN SMALL LETTER F -->
+      <map code="0x67" name="uni0067"/><!-- LATIN SMALL LETTER G -->
+      <map code="0x68" name="uni0068"/><!-- LATIN SMALL LETTER H -->
+      <map code="0x69" name="uni0069"/><!-- LATIN SMALL LETTER I -->
+      <map code="0x6a" name="uni006A"/><!-- LATIN SMALL LETTER J -->
+      <map code="0x6b" name="uni006B"/><!-- LATIN SMALL LETTER K -->
+      <map code="0x6c" name="uni006C"/><!-- LATIN SMALL LETTER L -->
+    </cmap_format_4>
+  </cmap>
+
+  <post>
+    <formatType value="3.0"/>
+    <italicAngle value="-12.5"/>
+    <underlinePosition value="-200"/>
+    <underlineThickness value="20"/>
+    <isFixedPitch value="0"/>
+    <minMemType42 value="0"/>
+    <maxMemType42 value="0"/>
+    <minMemType1 value="0"/>
+    <maxMemType1 value="0"/>
+  </post>
+
+  <CFF>
+    <major value="1"/>
+    <minor value="0"/>
+    <CFFFont name="SomeFont-Regular (Postscript Font Name)">
+      <version value="1.0"/>
+      <Notice value="Trademark Some Foundry"/>
+      <Copyright value="Copyright Copyright Some Foundry."/>
+      <FullName value="Some Font-Regular (Postscript Full Name)"/>
+      <FamilyName value="Some Font (Preferred Family Name)"/>
+      <Weight value="Medium"/>
+      <isFixedPitch value="0"/>
+      <ItalicAngle value="-12.5"/>
+      <UnderlinePosition value="-200"/>
+      <UnderlineThickness value="20"/>
+      <PaintType value="0"/>
+      <CharstringType value="2"/>
+      <FontMatrix value="0.001 0 0 0.001 0 0"/>
+      <FontBBox value="-55 -280 454 750"/>
+      <StrokeWidth value="0"/>
+      <!-- charset is dumped separately as the 'GlyphOrder' element -->
+      <Encoding name="StandardEncoding"/>
+      <Private>
+        <BlueValues value="500 510"/>
+        <OtherBlues value="-250 -260"/>
+        <FamilyBlues value="500 510"/>
+        <FamilyOtherBlues value="-250 -260"/>
+        <BlueScale value="0.039625"/>
+        <BlueShift value="7"/>
+        <BlueFuzz value="1"/>
+        <StdHW value="100"/>
+        <StdVW value="80"/>
+        <StemSnapH value="100 120"/>
+        <StemSnapV value="80 90"/>
+        <ForceBold value="1"/>
+        <LanguageGroup value="0"/>
+        <ExpansionFactor value="0.06"/>
+        <initialRandomSeed value="0"/>
+        <defaultWidthX value="400"/>
+        <nominalWidthX value="400"/>
+      </Private>
+      <CharStrings>
+        <CharString name=".notdef">
+          100 450 hmoveto
+          750 -400 -750 vlineto
+          350 50 rmoveto
+          -300 650 300 hlineto
+          endchar
+        </CharString>
+        <CharString name="uni0020">
+          -150 endchar
+        </CharString>
+        <CharString name="uni0061">
+          -12 66 hmoveto
+          256 hlineto
+          -128 510 rlineto
+          endchar
+        </CharString>
+        <CharString name="uni0062">
+          10 100 505 rmoveto
+          -510 210 510 vlineto
+          endchar
+        </CharString>
+        <CharString name="uni0063">
+          -26 300 -10 rmoveto
+          510 vlineto
+          -150 -50 -50 -205 -205 50 -50 150 hvcurveto
+          endchar
+        </CharString>
+        <CharString name="uni0064">
+          -26 151 197 rmoveto
+          -34 -27 -27 -33 -33 27 -27 34 33 27 27 33 33 -27 27 -33 hvcurveto
+          endchar
+        </CharString>
+        <CharString name="uni0065">
+          -12 66 510 rmoveto
+          128 -435 128 435 rlineto
+          -377 -487 rmoveto
+          509 hlineto
+          150 -50 50 -205 -204 -50 -50 -150 vhcurveto
+          endchar
+        </CharString>
+        <CharString name="uni0066">
+          10 66 510 rmoveto
+          256 hlineto
+          -128 -435 rlineto
+          -249 -52 rmoveto
+          509 hlineto
+          150 -50 50 -205 -204 -50 -50 -150 vhcurveto
+          endchar
+        </CharString>
+        <CharString name="uni0067">
+          -12 66 hmoveto
+          256 hlineto
+          -128 510 rlineto
+          endchar
+        </CharString>
+        <CharString name="uni0068">
+          10 211 657 rmoveto
+          -34 -27 -27 -33 -33 27 -27 34 33 27 27 33 33 -27 27 -33 hvcurveto
+          -111 -152 rmoveto
+          -510 210 510 vlineto
+          endchar
+        </CharString>
+        <CharString name="uni0069">
+          200 -55 -80 rmoveto
+          509 hlineto
+          149 -50 50 -205 -204 -50 -50 -149 vhcurveto
+          121 80 rmoveto
+          256 hlineto
+          -128 510 rlineto
+          endchar
+        </CharString>
+        <CharString name="uni006A">
+          200 -55 -80 rmoveto
+          509 hlineto
+          149 -50 50 -205 -204 -50 -50 -149 vhcurveto
+          121 310 rmoveto
+          128 -510 128 510 rlineto
+          endchar
+        </CharString>
+        <CharString name="uni006B">
+          200 66 hmoveto
+          256 hlineto
+          -128 510 rlineto
+          -28 -510 rmoveto
+          256 hlineto
+          -128 510 rlineto
+          endchar
+        </CharString>
+        <CharString name="uni006C">
+          200 334 hmoveto
+          -128 510 -128 -510 rlineto
+          88 hmoveto
+          256 hlineto
+          -128 510 rlineto
+          endchar
+        </CharString>
+      </CharStrings>
+    </CFFFont>
+
+    <GlobalSubrs>
+      <!-- The 'index' attribute is only for humans; it is ignored when parsed. -->
+    </GlobalSubrs>
+  </CFF>
+
+  <CUST raw="True">
+    <hexdata>
+      0001beef   
+    </hexdata>
+  </CUST>
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="kern"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="2"/>
+        <LookupFlag value="8"/>
+        <!-- SubTableCount=1 -->
+        <PairPos index="0" Format="1">
+          <Coverage Format="1">
+            <Glyph value="uni0061"/>
+            <Glyph value="uni0062"/>
+          </Coverage>
+          <ValueFormat1 value="4"/>
+          <ValueFormat2 value="0"/>
+          <!-- PairSetCount=2 -->
+          <PairSet index="0">
+            <!-- PairValueCount=3 -->
+            <PairValueRecord index="0">
+              <SecondGlyph value="uni0020"/>
+              <Value1 XAdvance="1"/>
+            </PairValueRecord>
+            <PairValueRecord index="1">
+              <SecondGlyph value="uni0061"/>
+              <Value1 XAdvance="5"/>
+            </PairValueRecord>
+            <PairValueRecord index="2">
+              <SecondGlyph value="uni0062"/>
+              <Value1 XAdvance="-10"/>
+            </PairValueRecord>
+          </PairSet>
+          <PairSet index="1">
+            <!-- PairValueCount=1 -->
+            <PairValueRecord index="0">
+              <SecondGlyph value="uni0061"/>
+              <Value1 XAdvance="-7"/>
+            </PairValueRecord>
+          </PairSet>
+        </PairPos>
+      </Lookup>
+    </LookupList>
+  </GPOS>
+
+  <VORG>
+    <majorVersion value="1"/>
+    <minorVersion value="0"/>
+    <defaultVertOriginY value="750"/>
+    <numVertOriginYMetrics value="0"/>
+  </VORG>
+
+  <hmtx>
+    <mtx name=".notdef" width="500" lsb="50"/>
+    <mtx name="uni0020" width="250" lsb="0"/>
+    <mtx name="uni0061" width="388" lsb="66"/>
+    <mtx name="uni0062" width="410" lsb="100"/>
+    <mtx name="uni0063" width="374" lsb="100"/>
+    <mtx name="uni0064" width="374" lsb="90"/>
+    <mtx name="uni0065" width="388" lsb="-55"/>
+    <mtx name="uni0066" width="410" lsb="-55"/>
+    <mtx name="uni0067" width="388" lsb="66"/>
+    <mtx name="uni0068" width="410" lsb="100"/>
+    <mtx name="uni0069" width="600" lsb="-55"/>
+    <mtx name="uni006A" width="600" lsb="-55"/>
+    <mtx name="uni006B" width="600" lsb="66"/>
+    <mtx name="uni006C" width="600" lsb="78"/>
+  </hmtx>
+
+  <vhea>
+    <tableVersion value="0x00011000"/>
+    <ascent value="750"/>
+    <descent value="-250"/>
+    <lineGap value="200"/>
+    <advanceHeightMax value="1000"/>
+    <minTopSideBearing value="0"/>
+    <minBottomSideBearing value="-80"/>
+    <yMaxExtent value="1030"/>
+    <caretSlopeRise value="0"/>
+    <caretSlopeRun value="1"/>
+    <caretOffset value="0"/>
+    <reserved1 value="0"/>
+    <reserved2 value="0"/>
+    <reserved3 value="0"/>
+    <reserved4 value="0"/>
+    <metricDataFormat value="0"/>
+    <numberOfVMetrics value="12"/>
+  </vhea>
+
+  <vmtx>
+    <mtx name=".notdef" height="1000" tsb="0"/>
+    <mtx name="uni0020" height="250" tsb="750"/>
+    <mtx name="uni0061" height="750" tsb="240"/>
+    <mtx name="uni0062" height="750" tsb="245"/>
+    <mtx name="uni0063" height="750" tsb="250"/>
+    <mtx name="uni0064" height="750" tsb="553"/>
+    <mtx name="uni0065" height="750" tsb="240"/>
+    <mtx name="uni0066" height="750" tsb="240"/>
+    <mtx name="uni0067" height="750" tsb="240"/>
+    <mtx name="uni0068" height="1000" tsb="93"/>
+    <mtx name="uni0069" height="750" tsb="240"/>
+    <mtx name="uni006A" height="1000" tsb="520"/>
+    <mtx name="uni006B" height="1000" tsb="240"/>
+    <mtx name="uni006C" height="1000" tsb="240"/>
+  </vmtx>
+
+</ttFont>

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -117,6 +117,18 @@ class IntegrationTest(object):
         expectTTX(ttfs[0], "TestFont.ttx")
         expectTTX(ttfs[1], "TestFont.ttx")
 
+    def test_optimizeCFF_none(self, testufo):
+        otf = compileOTF(testufo, optimizeCFF=0)
+        expectTTX(otf, "TestFont-NoOptimize-CFF.ttx")
+
+    def test_optimizeCFF_specialize(self, testufo):
+        otf = compileOTF(testufo, optimizeCFF=1)
+        expectTTX(otf, "TestFont-Specialized-CFF.ttx")
+
+    def test_optimizeCFF_subroutinize(self, testufo):
+        otf = compileOTF(testufo, optimizeCFF=2)
+        expectTTX(otf, "TestFont-CFF.ttx")
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main(sys.argv))

--- a/tests/outlineCompiler_test.py
+++ b/tests/outlineCompiler_test.py
@@ -377,6 +377,52 @@ class OutlineOTFCompilerTest(object):
             ],
         )
 
+    def test_setupTable_CFF_optimize(self, testufo):
+        compiler = OutlineOTFCompiler(testufo, optimizeCFF=True)
+        otf = compiler.otf = TTFont(sfntVersion="OTTO")
+
+        compiler.setupTable_CFF()
+        program = self.get_charstring_program(otf, "a")
+
+        self.assertProgramEqual(
+            program,
+            [
+                -12,
+                66,
+                'hmoveto',
+                256,
+                'hlineto',
+                -128,
+                510,
+                'rlineto',
+                'endchar'
+            ]
+        )
+
+    def test_setupTable_CFF_no_optimize(self, testufo):
+        compiler = OutlineOTFCompiler(testufo, optimizeCFF=False)
+        otf = compiler.otf = TTFont(sfntVersion="OTTO")
+
+        compiler.setupTable_CFF()
+        program = self.get_charstring_program(otf, "a")
+
+        self.assertProgramEqual(
+            program,
+            [
+                -12,
+                66,
+                0,
+                'rmoveto',
+                256,
+                0,
+                'rlineto',
+                -128,
+                510,
+                'rlineto',
+                'endchar'
+            ],
+        )
+
     def test_makeGlyphsBoundingBoxes(self, testufo):
         # the call to 'makeGlyphsBoundingBoxes' happen in the __init__ method
         compiler = OutlineOTFCompiler(testufo)


### PR DESCRIPTION
The fonttools' `T2CharStringPen.getCharString` method takes an 'optimize' option (True by default), which passes the charstring program through the `fontTools.cffLib.specializer` module.

Sometimes one may want to have the CFF charstrings un-specialized (e.g. if one wants to merge CFF tables into a CFF2 like in https://github.com/adobe-type-tools/afdko/issues/657), so here we re-use the existing ufo2ft's 'optimizeCFF' option, which previously was only used to control the CFF subroutinization post-process.

I think it makes more sense to not add an additional option that only controls the CFF specializer, but use the same option that enables/disables the subroutinization, as the two optimizations naturally go together.