### PR TITLE
WIP: Implement selective layer compilation

### DIFF
--- a/Lib/ufo2ft/preProcessor.py
+++ b/Lib/ufo2ft/preProcessor.py
@@ -28,13 +28,13 @@ class BasePreProcessor(object):
     "com.github.googlei18n.ufo2ft.filters".
     """
 
-    def __init__(self, ufo, inplace=False, **kwargs):
+    def __init__(self, ufo, inplace=False, layerName="public.default", **kwargs):
         self.ufo = ufo
         self.inplace = inplace
         if inplace:
-            self.glyphSet = {g.name: g for g in ufo}
+            self.glyphSet = {g.name: g for g in ufo.layers[layerName]}
         else:
-            self.glyphSet = copyGlyphSet(ufo)
+            self.glyphSet = copyGlyphSet(ufo, layerName=layerName)
         self.defaultFilters = self.initDefaultFilters(**kwargs)
         self.preFilters, self.postFilters = loadFilters(ufo)
 
@@ -165,15 +165,26 @@ class TTFInterpolatablePreProcessor(object):
     """
 
     def __init__(self, ufos, inplace=False, conversionError=None,
-                 reverseDirection=True, rememberCurveType=True):
+                 reverseDirection=True, rememberCurveType=True,
+                 layerNames=None):
         from cu2qu.ufo import DEFAULT_MAX_ERR
+
+        if layerNames is None:
+            layerNames = ["public.default"] * len(ufos)
+        assert len(ufos) == len(layerNames)
 
         self.ufos = ufos
         self.inplace = inplace
         if inplace:
-            self.glyphSets = [{g.name: g for g in ufo} for ufo in ufos]
+            self.glyphSets = [
+                {g.name: g for g in ufo.layers[layerName]}
+                for ufo, layerName in zip(ufos, layerNames)
+            ]
         else:
-            self.glyphSets = [copyGlyphSet(ufo) for ufo in ufos]
+            self.glyphSets = [
+                copyGlyphSet(ufo, layerName=layerName)
+                for ufo, layerName in zip(ufos, layerNames)
+            ]
         self._conversionErrors = [
             (conversionError or DEFAULT_MAX_ERR) * ufo.info.unitsPerEm
             for ufo in ufos]

--- a/tests/data/LayerFont-Bold.ufo/features.fea
+++ b/tests/data/LayerFont-Bold.ufo/features.fea
@@ -1,0 +1,3 @@
+feature liga {
+	sub a e s s by s;
+} liga;

--- a/tests/data/LayerFont-Bold.ufo/fontinfo.plist
+++ b/tests/data/LayerFont-Bold.ufo/fontinfo.plist
@@ -1,0 +1,64 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>ascender</key>
+    <integer>750</integer>
+    <key>capHeight</key>
+    <integer>700</integer>
+    <key>copyright</key>
+    <string></string>
+    <key>descender</key>
+    <integer>-250</integer>
+    <key>familyName</key>
+    <string>Layer Font</string>
+    <key>guidelines</key>
+    <array/>
+    <key>italicAngle</key>
+    <integer>0</integer>
+    <key>note</key>
+    <string></string>
+    <key>openTypeHeadCreated</key>
+    <string>2018/11/21 11:49:03</string>
+    <key>openTypeNameDesigner</key>
+    <string></string>
+    <key>openTypeNameDesignerURL</key>
+    <string></string>
+    <key>openTypeNameLicense</key>
+    <string></string>
+    <key>openTypeNameLicenseURL</key>
+    <string></string>
+    <key>openTypeNameManufacturer</key>
+    <string></string>
+    <key>openTypeNameManufacturerURL</key>
+    <string></string>
+    <key>postscriptBlueValues</key>
+    <array/>
+    <key>postscriptFamilyBlues</key>
+    <array/>
+    <key>postscriptFamilyOtherBlues</key>
+    <array/>
+    <key>postscriptOtherBlues</key>
+    <array/>
+    <key>postscriptStemSnapH</key>
+    <array/>
+    <key>postscriptStemSnapV</key>
+    <array/>
+    <key>postscriptUnderlinePosition</key>
+    <integer>-100</integer>
+    <key>postscriptUnderlineThickness</key>
+    <integer>50</integer>
+    <key>styleName</key>
+    <string>Bold</string>
+    <key>trademark</key>
+    <string></string>
+    <key>unitsPerEm</key>
+    <integer>1000</integer>
+    <key>versionMajor</key>
+    <integer>0</integer>
+    <key>versionMinor</key>
+    <integer>0</integer>
+    <key>xHeight</key>
+    <integer>500</integer>
+  </dict>
+</plist>

--- a/tests/data/LayerFont-Bold.ufo/glyphs/a.glif
+++ b/tests/data/LayerFont-Bold.ufo/glyphs/a.glif
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="a" format="2">
+  <advance width="600.0"/>
+  <unicode hex="0061"/>
+  <outline>
+    <contour>
+      <point x="468.0" y="-1.0" type="line"/>
+      <point x="447.0" y="434.0" type="line"/>
+      <point x="214.0" y="504.0" type="line"/>
+      <point x="9.0" y="428.0" type="line"/>
+      <point x="36.0" y="281.0" type="line"/>
+      <point x="208.0" y="341.0" type="line"/>
+      <point x="304.0" y="303.0" type="line"/>
+      <point x="307.0" y="-1.0" type="line"/>
+    </contour>
+    <contour>
+      <point x="378.0" y="263.0" type="line"/>
+      <point x="26.0" y="240.0" type="line"/>
+      <point x="29.0" y="22.0" type="line"/>
+      <point x="168.0" y="-12.0" type="line"/>
+      <point x="389.0" y="71.0" type="line"/>
+      <point x="383.0" y="149.0" type="line"/>
+      <point x="201.0" y="102.0" type="line"/>
+      <point x="163.0" y="133.0" type="line"/>
+      <point x="165.0" y="179.0" type="line"/>
+      <point x="381.0" y="184.0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/tests/data/LayerFont-Bold.ufo/glyphs/contents.plist
+++ b/tests/data/LayerFont-Bold.ufo/glyphs/contents.plist
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>a</key>
+    <string>a.glif</string>
+    <key>dotabovecomb</key>
+    <string>dotabovecomb.glif</string>
+    <key>e</key>
+    <string>e.glif</string>
+    <key>edotabove</key>
+    <string>edotabove.glif</string>
+    <key>s</key>
+    <string>s.glif</string>
+  </dict>
+</plist>

--- a/tests/data/LayerFont-Bold.ufo/glyphs/dotabovecomb.glif
+++ b/tests/data/LayerFont-Bold.ufo/glyphs/dotabovecomb.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="dotabovecomb" format="2">
+  <unicode hex="0307"/>
+  <anchor x="-2" y="465" name="_top"/>
+  <outline>
+    <contour>
+      <point x="-29.0" y="625.0" type="line"/>
+      <point x="-64.0" y="483.0" type="line"/>
+      <point x="58.0" y="488.0" type="line"/>
+      <point x="63.0" y="605.0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/tests/data/LayerFont-Bold.ufo/glyphs/e.glif
+++ b/tests/data/LayerFont-Bold.ufo/glyphs/e.glif
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="e" format="2">
+  <advance width="600"/>
+  <unicode hex="0065"/>
+  <anchor x="315.32105263157894" y="644.0078947368421" name="top"/>
+  <outline>
+    <contour>
+      <point x="197.0" y="229.0" type="line"/>
+      <point x="601.0" y="225.0" type="line"/>
+      <point x="596.0" y="304.0" type="line"/>
+      <point x="314.0" y="548.0" type="line"/>
+      <point x="9.0" y="262.0" type="line"/>
+      <point x="188.0" y="-18.0" type="line"/>
+      <point x="528.0" y="0.0" type="line"/>
+      <point x="524.0" y="184.0" type="line"/>
+      <point x="244.0" y="130.0" type="line"/>
+      <point x="217.0" y="264.0" type="line"/>
+      <point x="301.0" y="360.0" type="line"/>
+      <point x="404.0" y="293.0" type="line"/>
+      <point x="195.0" y="299.0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/tests/data/LayerFont-Bold.ufo/glyphs/edotabove.glif
+++ b/tests/data/LayerFont-Bold.ufo/glyphs/edotabove.glif
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="edotabove" format="2">
+  <advance width="600"/>
+  <unicode hex="0117"/>
+  <outline>
+    <component base="e"/>
+    <component base="dotabovecomb" xOffset="307.4387811634349" yOffset="187.1620498614958"/>
+  </outline>
+</glyph>

--- a/tests/data/LayerFont-Bold.ufo/glyphs/s.glif
+++ b/tests/data/LayerFont-Bold.ufo/glyphs/s.glif
@@ -1,0 +1,21 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="s" format="2">
+  <advance width="600"/>
+  <unicode hex="0073"/>
+  <outline>
+    <contour>
+      <point x="559.0" y="459.0" type="line"/>
+      <point x="324.0" y="530.0" type="line"/>
+      <point x="16.0" y="398.0" type="line"/>
+      <point x="347.0" y="149.0" type="line"/>
+      <point x="221.0" y="119.0" type="line"/>
+      <point x="26.0" y="226.0" type="line"/>
+      <point x="7.0" y="79.0" type="line"/>
+      <point x="284.0" y="-58.0" type="line"/>
+      <point x="608.0" y="141.0" type="line"/>
+      <point x="268.0" y="357.0" type="line"/>
+      <point x="324.0" y="402.0" type="line"/>
+      <point x="537.0" y="336.0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/tests/data/LayerFont-Bold.ufo/layercontents.plist
+++ b/tests/data/LayerFont-Bold.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <array>
+      <string>public.default</string>
+      <string>glyphs</string>
+    </array>
+  </array>
+</plist>

--- a/tests/data/LayerFont-Bold.ufo/lib.plist
+++ b/tests/data/LayerFont-Bold.ufo/lib.plist
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>public.glyphOrder</key>
+    <array>
+      <string>a</string>
+      <string>e</string>
+      <string>s</string>
+      <string>dotabovecomb</string>
+      <string>edotabove</string>
+    </array>
+  </dict>
+</plist>

--- a/tests/data/LayerFont-Bold.ufo/metainfo.plist
+++ b/tests/data/LayerFont-Bold.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>creator</key>
+    <string>com.github.fonttools.ufoLib</string>
+    <key>formatVersion</key>
+    <integer>3</integer>
+  </dict>
+</plist>

--- a/tests/data/LayerFont-Regular.ufo/features.fea
+++ b/tests/data/LayerFont-Regular.ufo/features.fea
@@ -1,0 +1,3 @@
+feature liga {
+	sub a e s s by s;
+} liga;

--- a/tests/data/LayerFont-Regular.ufo/fontinfo.plist
+++ b/tests/data/LayerFont-Regular.ufo/fontinfo.plist
@@ -1,0 +1,60 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>ascender</key>
+    <integer>750</integer>
+    <key>capHeight</key>
+    <integer>700</integer>
+    <key>copyright</key>
+    <string></string>
+    <key>descender</key>
+    <integer>-250</integer>
+    <key>familyName</key>
+    <string>Layer Font</string>
+    <key>guidelines</key>
+    <array/>
+    <key>italicAngle</key>
+    <integer>0</integer>
+    <key>note</key>
+    <string></string>
+    <key>openTypeHeadCreated</key>
+    <string>2018/11/21 11:49:03</string>
+    <key>openTypeNameDesigner</key>
+    <string></string>
+    <key>openTypeNameDesignerURL</key>
+    <string></string>
+    <key>openTypeNameLicense</key>
+    <string></string>
+    <key>openTypeNameLicenseURL</key>
+    <string></string>
+    <key>openTypeNameManufacturer</key>
+    <string></string>
+    <key>openTypeNameManufacturerURL</key>
+    <string></string>
+    <key>postscriptBlueValues</key>
+    <array/>
+    <key>postscriptFamilyBlues</key>
+    <array/>
+    <key>postscriptFamilyOtherBlues</key>
+    <array/>
+    <key>postscriptOtherBlues</key>
+    <array/>
+    <key>postscriptStemSnapH</key>
+    <array/>
+    <key>postscriptStemSnapV</key>
+    <array/>
+    <key>styleName</key>
+    <string>Regular</string>
+    <key>trademark</key>
+    <string></string>
+    <key>unitsPerEm</key>
+    <integer>1000</integer>
+    <key>versionMajor</key>
+    <integer>0</integer>
+    <key>versionMinor</key>
+    <integer>0</integer>
+    <key>xHeight</key>
+    <integer>500</integer>
+  </dict>
+</plist>

--- a/tests/data/LayerFont-Regular.ufo/glyphs.M_edium/contents.plist
+++ b/tests/data/LayerFont-Regular.ufo/glyphs.M_edium/contents.plist
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>e</key>
+    <string>e.glif</string>
+  </dict>
+</plist>

--- a/tests/data/LayerFont-Regular.ufo/glyphs.M_edium/e.glif
+++ b/tests/data/LayerFont-Regular.ufo/glyphs.M_edium/e.glif
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="e" format="2">
+  <advance width="600"/>
+  <anchor x="403.20000000000005" y="567.3000000000001" name="top"/>
+  <outline>
+    <contour>
+      <point x="126.0" y="203.0" type="line"/>
+      <point x="576.0" y="199.0" type="line"/>
+      <point x="571.0" y="305.0" type="line"/>
+      <point x="316.0" y="513.0" type="line"/>
+      <point x="40.0" y="261.0" type="line"/>
+      <point x="188.0" y="-18.0" type="line"/>
+      <point x="526.0" y="45.0" type="line"/>
+      <point x="507.0" y="157.0" type="line"/>
+      <point x="264.0" y="116.0" type="line"/>
+      <point x="180.0" y="264.0" type="line"/>
+      <point x="318.0" y="387.0" type="line"/>
+      <point x="396.0" y="297.0" type="line"/>
+      <point x="125.0" y="298.0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/tests/data/LayerFont-Regular.ufo/glyphs/a.glif
+++ b/tests/data/LayerFont-Regular.ufo/glyphs/a.glif
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="a" format="2">
+  <advance width="600.0"/>
+  <unicode hex="0061"/>
+  <outline>
+    <contour>
+      <point x="468.0" y="-1.0" type="line"/>
+      <point x="447.0" y="434.0" type="line"/>
+      <point x="214.0" y="504.0" type="line"/>
+      <point x="9.0" y="428.0" type="line"/>
+      <point x="36.0" y="337.0" type="line"/>
+      <point x="208.0" y="397.0" type="line"/>
+      <point x="363.0" y="357.0" type="line"/>
+      <point x="366.0" y="-3.0" type="line"/>
+    </contour>
+    <contour>
+      <point x="378.0" y="263.0" type="line"/>
+      <point x="26.0" y="240.0" type="line"/>
+      <point x="29.0" y="22.0" type="line"/>
+      <point x="168.0" y="-12.0" type="line"/>
+      <point x="389.0" y="71.0" type="line"/>
+      <point x="383.0" y="134.0" type="line"/>
+      <point x="161.0" y="74.0" type="line"/>
+      <point x="86.0" y="126.0" type="line"/>
+      <point x="88.0" y="172.0" type="line"/>
+      <point x="382.0" y="207.0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/tests/data/LayerFont-Regular.ufo/glyphs/contents.plist
+++ b/tests/data/LayerFont-Regular.ufo/glyphs/contents.plist
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>a</key>
+    <string>a.glif</string>
+    <key>dotabovecomb</key>
+    <string>dotabovecomb.glif</string>
+    <key>e</key>
+    <string>e.glif</string>
+    <key>edotabove</key>
+    <string>edotabove.glif</string>
+    <key>s</key>
+    <string>s.glif</string>
+  </dict>
+</plist>

--- a/tests/data/LayerFont-Regular.ufo/glyphs/dotabovecomb.glif
+++ b/tests/data/LayerFont-Regular.ufo/glyphs/dotabovecomb.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="dotabovecomb" format="2">
+  <unicode hex="0307"/>
+  <anchor x="-2" y="465" name="_top"/>
+  <outline>
+    <contour>
+      <point x="-21" y="597" type="line"/>
+      <point x="-37" y="503" type="line"/>
+      <point x="41" y="501" type="line"/>
+      <point x="50" y="589" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/tests/data/LayerFont-Regular.ufo/glyphs/e.glif
+++ b/tests/data/LayerFont-Regular.ufo/glyphs/e.glif
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="e" format="2">
+  <advance width="600"/>
+  <unicode hex="0065"/>
+  <anchor x="314" y="556" name="top"/>
+  <outline>
+    <contour>
+      <point x="127.0" y="228.0" type="line"/>
+      <point x="576.0" y="226.0" type="line"/>
+      <point x="571.0" y="305.0" type="line"/>
+      <point x="316.0" y="513.0" type="line"/>
+      <point x="40.0" y="261.0" type="line"/>
+      <point x="188.0" y="-18.0" type="line"/>
+      <point x="526.0" y="45.0" type="line"/>
+      <point x="509.0" y="129.0" type="line"/>
+      <point x="229.0" y="75.0" type="line"/>
+      <point x="147.0" y="263.0" type="line"/>
+      <point x="317.0" y="416.0" type="line"/>
+      <point x="480.0" y="292.0" type="line"/>
+      <point x="125.0" y="298.0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/tests/data/LayerFont-Regular.ufo/glyphs/edotabove.glif
+++ b/tests/data/LayerFont-Regular.ufo/glyphs/edotabove.glif
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="edotabove" format="2">
+  <advance width="600"/>
+  <unicode hex="0117"/>
+  <outline>
+    <component base="e"/>
+    <component base="dotabovecomb" xOffset="313.2105263157895" yOffset="96.15789473684208"/>
+  </outline>
+</glyph>

--- a/tests/data/LayerFont-Regular.ufo/glyphs/s.glif
+++ b/tests/data/LayerFont-Regular.ufo/glyphs/s.glif
@@ -1,0 +1,21 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="s" format="2">
+  <advance width="600"/>
+  <unicode hex="0073"/>
+  <outline>
+    <contour>
+      <point x="559.0" y="459.0" type="line"/>
+      <point x="324.0" y="530.0" type="line"/>
+      <point x="38.0" y="343.0" type="line"/>
+      <point x="427.0" y="155.0" type="line"/>
+      <point x="282.0" y="76.0" type="line"/>
+      <point x="53.0" y="174.0" type="line"/>
+      <point x="25.0" y="83.0" type="line"/>
+      <point x="304.0" y="-13.0" type="line"/>
+      <point x="582.0" y="174.0" type="line"/>
+      <point x="213.0" y="366.0" type="line"/>
+      <point x="326.0" y="442.0" type="line"/>
+      <point x="539.0" y="376.0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/tests/data/LayerFont-Regular.ufo/layercontents.plist
+++ b/tests/data/LayerFont-Regular.ufo/layercontents.plist
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <array>
+      <string>public.default</string>
+      <string>glyphs</string>
+    </array>
+    <array>
+      <string>Medium</string>
+      <string>glyphs.M_edium</string>
+    </array>
+  </array>
+</plist>

--- a/tests/data/LayerFont-Regular.ufo/lib.plist
+++ b/tests/data/LayerFont-Regular.ufo/lib.plist
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>public.glyphOrder</key>
+    <array>
+      <string>a</string>
+      <string>e</string>
+      <string>s</string>
+      <string>dotabovecomb</string>
+      <string>edotabove</string>
+    </array>
+  </dict>
+</plist>

--- a/tests/data/LayerFont-Regular.ufo/metainfo.plist
+++ b/tests/data/LayerFont-Regular.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>creator</key>
+    <string>com.github.fonttools.ufoLib</string>
+    <key>formatVersion</key>
+    <integer>3</integer>
+  </dict>
+</plist>


### PR DESCRIPTION
Work to equip `compileTTF` and `compileOTF` with a `layerName` kwarg and `compileInterpolatableTTFs` with a `layerNames` kwarg to only compile selected layers as a sparse master.

Currently, no features are compiled for these sparse masters from layers. What do we need? I'm thinking of e.g. moving anchors and having the mark-to-mark attachment work as expected -- or is this not necessary?