### PR TITLE
Style map names

### DIFF
--- a/Lib/ufo2ft/fontInfoData.py
+++ b/Lib/ufo2ft/fontInfoData.py
@@ -34,16 +34,40 @@ logger = logging.getLogger(__name__)
 # -----------------
 
 # generic
+_styleMapStyleNames = ["regular", "bold", "italic", "bold italic"]
 
 def styleMapFamilyNameFallback(info):
     """
-    Fallback to *openTypeNamePreferredFamilyName openTypeNamePreferredSubfamilyName*.
+    Fallback to *openTypeNamePreferredFamilyName* if
+    *styleMapStyleName* or, if *styleMapStyleName* isn’t defined,
+    *openTypeNamePreferredSubfamilyName* is
+    *regular*, *bold*, *italic* or *bold italic*, otherwise
+    fallback to *openTypeNamePreferredFamilyName openTypeNamePreferredFamilyName*.
     """
     familyName = getAttrWithFallback(info, "openTypeNamePreferredFamilyName")
-    styleName = getAttrWithFallback(info, "openTypeNamePreferredSubfamilyName")
+    styleName = info.styleMapStyleName
+    if not styleName:
+        styleName = getAttrWithFallback(info, "openTypeNamePreferredSubfamilyName")
     if styleName is None:
         styleName = ""
+    elif styleName.lower() in _styleMapStyleNames:
+        styleName = ""
     return (familyName + " " + styleName).strip()
+
+def styleMapStyleNameFallback(info):
+    """
+    Fallback to *openTypeNamePreferredSubfamilyName* if
+    it is one of *regular*, *bold*, *italic*, *bold italic*, otherwise
+    fallback to *regular*.
+    """
+    styleName = getAttrWithFallback(info, "openTypeNamePreferredSubfamilyName")
+    if styleName is None:
+        styleName = "regular"
+    elif styleName.strip().lower() not in _styleMapStyleNames:
+        styleName = "regular"
+    else:
+        styleName = styleName.strip().lower()
+    return styleName
 
 # head
 
@@ -273,7 +297,6 @@ def postscriptBlueScaleFallback(info):
 # --------------
 
 staticFallbackData = dict(
-    styleMapStyleName="regular",
     versionMajor=0,
     versionMinor=0,
     copyright=None,
@@ -359,6 +382,7 @@ staticFallbackData = dict(
 
 specialFallbacks = dict(
     styleMapFamilyName=styleMapFamilyNameFallback,
+    styleMapStyleName=styleMapStyleNameFallback,
     openTypeHeadCreated=openTypeHeadCreatedFallback,
     openTypeHheaAscender=openTypeHheaAscenderFallback,
     openTypeHheaDescender=openTypeHheaDescenderFallback,

--- a/tests/fontInfoData_test.py
+++ b/tests/fontInfoData_test.py
@@ -27,23 +27,85 @@ def info(InfoClass):
 
 class GetAttrWithFallbackTest(object):
 
-    def test_family_and_style_names(self, info):
-        assert getAttrWithFallback(info, "familyName") == "Family Name"
-        assert getAttrWithFallback(info, "styleName") == "Style Name"
-
-        assert (getAttrWithFallback(info, "styleMapFamilyName")
-                == "Family Name Style Name")
-
-        info.styleMapFamilyName = "Style Map Family Name"
-        assert (getAttrWithFallback(info, "styleMapFamilyName")
-                == "Style Map Family Name")
-
-        assert (getAttrWithFallback(info, "openTypeNamePreferredFamilyName")
-                == "Family Name")
-        assert (getAttrWithFallback(info, "openTypeNamePreferredSubfamilyName")
-                == "Style Name")
-        assert (getAttrWithFallback(info, "openTypeNameCompatibleFullName")
-                == "Style Map Family Name")
+    @pytest.mark.parametrize("infoDict,expected", [
+        # no styleMapFamilyName, no styleMapStyleName
+        ({},
+         {
+             "familyName": "Family Name",
+             "styleName": "Style Name",
+             "styleMapFamilyName": "Family Name Style Name",
+             "styleMapStyleName": "regular",
+             "openTypeNamePreferredFamilyName": "Family Name",
+             "openTypeNamePreferredSubfamilyName": "Style Name",
+             "openTypeNameCompatibleFullName": "Family Name Style Name",
+         }),
+        # no styleMapStyleName
+        ({
+             "styleMapFamilyName": "Style Map Family Name",
+         },
+         {
+             "styleMapFamilyName": "Style Map Family Name",
+             "styleMapStyleName": "regular",
+             "openTypeNamePreferredFamilyName": "Family Name",
+             "openTypeNamePreferredSubfamilyName": "Style Name",
+             "openTypeNameCompatibleFullName": "Style Map Family Name",
+         }),
+        # no styleMapFamilyName, no styleMapStyleName but styleName="Regular"
+        ({
+             "styleName": "Regular",
+         },
+         {
+             "familyName": "Family Name",
+             "styleName": "Regular",
+             "styleMapFamilyName": "Family Name",
+             "styleMapStyleName": "regular",
+             "openTypeNamePreferredFamilyName": "Family Name",
+             "openTypeNamePreferredSubfamilyName": "Regular",
+             "openTypeNameCompatibleFullName": "Family Name",
+         }),
+        # no styleMapFamilyName but styleName="Regular"
+        ({
+             "styleName": "Regular",
+             "styleMapStyleName": "regular",
+         },
+         {
+             "styleMapFamilyName": "Family Name",
+             "styleMapStyleName": "regular",
+             "openTypeNamePreferredFamilyName": "Family Name",
+             "openTypeNamePreferredSubfamilyName": "Regular",
+             "openTypeNameCompatibleFullName": "Family Name",
+         }),
+        # no styleMapStyleName but styleName="Regular"
+        ({
+             "styleName": "Regular",
+             "styleMapFamilyName": "Style Map Family Name",
+         },
+         {
+             "styleMapFamilyName": "Style Map Family Name",
+             "styleMapStyleName": "regular",
+             "openTypeNamePreferredFamilyName": "Family Name",
+             "openTypeNamePreferredSubfamilyName": "Regular",
+             "openTypeNameCompatibleFullName": "Style Map Family Name",
+         }),
+        # no styleMapFamilyName, no styleMapStyleName but styleName="Bold"
+        ({
+             "styleName": "Bold",
+         },
+         {
+             "familyName": "Family Name",
+             "styleName": "Bold",
+             "styleMapFamilyName": "Family Name",
+             "styleMapStyleName": "bold",
+             "openTypeNamePreferredFamilyName": "Family Name",
+             "openTypeNamePreferredSubfamilyName": "Bold",
+             "openTypeNameCompatibleFullName": "Family Name Bold",
+         }),
+    ])
+    def test_family_and_style_names(self, info, infoDict, expected):
+        for key, value in infoDict.items():
+            setattr(info, key, value)
+        for key, value in expected.items():
+            assert getAttrWithFallback(info, key) == value
 
     def test_redundant_metadata(self, info):
         assert (getAttrWithFallback(info, "openTypeNameVersion")


### PR DESCRIPTION
If a UFO doesn’t have `info.styleMapFamilyName`, `info.styleMapStyleName` defined, ufo2ft generates name tables with nameID1 as `info.openTypePreferredFamilyName + " " + info.openTypePreferredSubfamilyName` or as fallback `info.familyName + " " + info.styleName`.
This means one can end up with fonts with nameID1 = "Some Sans Regular" and nameID2= "Regular".