### PR TITLE
only build minimal metrics/outline tables for sparse layer masters

### DIFF
--- a/Lib/ufo2ft/__init__.py
+++ b/Lib/ufo2ft/__init__.py
@@ -258,6 +258,17 @@ def compileInterpolatableTTFs(
         postProcessor = PostProcessor(ttf, ufo, glyphSet=glyphSet)
         ttf = postProcessor.process(useProductionNames)
 
+        if layerName is not None:
+            # for sparse masters (i.e. containing only a subset of the glyphs), we
+            # need to include the post table in order to store glyph names, so that
+            # fontTools.varLib can interpolate glyphs with same name across masters.
+            # However we want to prevent the underlinePosition/underlineThickness
+            # fields in such sparse masters to be included when computing the deltas
+            # for the MVAR table. Thus, we set them to this unlikely, limit value
+            # (-36768) which is a signal varLib should ignore them when building MVAR.
+            ttf["post"].underlinePosition = -0x8000
+            ttf["post"].underlineThickness = -0x8000
+
         yield ttf
 
 

--- a/Lib/ufo2ft/__init__.py
+++ b/Lib/ufo2ft/__init__.py
@@ -17,6 +17,7 @@ from ufo2ft.featureCompiler import (
 )
 from ufo2ft.outlineCompiler import OutlineOTFCompiler, OutlineTTFCompiler
 from ufo2ft.postProcessor import PostProcessor
+from ufo2ft.constants import SPARSE_TTF_MASTER_TABLES, SPARSE_OTF_MASTER_TABLES
 import logging
 
 try:
@@ -48,6 +49,7 @@ def compileOTF(
     overlapsBackend=None,
     inplace=False,
     layerName=None,
+    _tables=None,
 ):
     """Create FontTools CFF font from a UFO.
 
@@ -81,9 +83,8 @@ def compileOTF(
     **inplace** (bool) specifies whether the filters should modify the input
       UFO's glyphs, a copy should be made first.
 
-    *layerName* specifies which layer should be compiled. Useful for generating
-      sparse masters. When compiling something other than the default layer,
-      feature compilation is skipped.
+    *layerName* specifies which layer should be compiled. When compiling something
+    other than the default layer, feature compilation is skipped.
     """
     logger.info("Pre-processing glyphs")
     preProcessor = preProcessorClass(
@@ -103,6 +104,7 @@ def compileOTF(
         glyphOrder=glyphOrder,
         roundTolerance=roundTolerance,
         optimizeCFF=optimizeCFF >= CFFOptimization.SPECIALIZE,
+        tables=_tables,
     )
     otf = outlineCompiler.compile()
 
@@ -149,9 +151,8 @@ def compileTTF(
     *convertCubics* and *cubicConversionError* specify how the conversion from cubic
     to quadratic curves should be handled.
 
-    *layerName* specifies which layer should be compiled. Useful for generating
-    sparse masters. When compiling something other than the default layer,
-    feature compilation is skipped.
+    *layerName* specifies which layer should be compiled. When compiling something
+    other than the default layer, feature compilation is skipped.
     """
     logger.info("Pre-processing glyphs")
     preProcessor = preProcessorClass(
@@ -211,6 +212,10 @@ def compileInterpolatableTTFs(
     *layerNames* refers to the layer names to use glyphs from in the order of
     the UFOs in *ufos*. By default, this is a list of `[None]` times the number
     of UFOs, i.e. using the default layer from all the UFOs.
+
+    When the layerName is not None for a given UFO, the corresponding TTFont object
+    will contain only a minimum set of tables ("head", "hmtx", "glyf", "loca", "maxp",
+    "post" and "vmtx"), and no OpenType layout tables.
     """
     from ufo2ft.util import _LazyFontName
 
@@ -232,7 +237,10 @@ def compileInterpolatableTTFs(
         logger.info("Building OpenType tables for %s", _LazyFontName(ufo))
 
         outlineCompiler = outlineCompilerClass(
-            ufo, glyphSet=glyphSet, glyphOrder=glyphOrder
+            ufo,
+            glyphSet=glyphSet,
+            glyphOrder=glyphOrder,
+            tables=SPARSE_TTF_MASTER_TABLES if layerName else None,
         )
         ttf = outlineCompiler.compile()
 
@@ -277,6 +285,10 @@ def compileInterpolatableTTFsFromDS(
     Return a copy of the DesignSpaceDocument object (or the same one if
     inplace=True) with the source's 'font' attribute set to the corresponding
     TTFont instance.
+
+    For sources that have the 'layerName' attribute defined, the corresponding TTFont
+    object will contain only a minimum set of tables ("head", "hmtx", "glyf", "loca",
+    "maxp", "post" and "vmtx"), and no OpenType layout tables.
     """
     ufos, layerNames = [], []
     for source in designSpaceDoc.sources:
@@ -338,6 +350,10 @@ def compileInterpolatableOTFsFromDS(
     Return a copy of the DesignSpaceDocument object (or the same one if
     inplace=True) with the source's 'font' attribute set to the corresponding
     TTFont instance.
+
+    For sources that have the 'layerName' attribute defined, the corresponding TTFont
+    object will contain only a minimum set of tables ("head", "hmtx", "CFF ", "maxp",
+    "vmtx" and "VORG"), and no OpenType layout tables.
     """
     for source in designSpaceDoc.sources:
         if source.font is None:
@@ -363,6 +379,7 @@ def compileInterpolatableOTFsFromDS(
                 removeOverlaps=False,
                 overlapsBackend=None,
                 inplace=inplace,
+                _tables=SPARSE_OTF_MASTER_TABLES if source.layerName else None,
             )
         )
 

--- a/Lib/ufo2ft/constants.py
+++ b/Lib/ufo2ft/constants.py
@@ -1,8 +1,12 @@
 from __future__ import absolute_import, unicode_literals
 
+SPARSE_TTF_MASTER_TABLES = frozenset(
+    ["glyf", "head", "hmtx", "loca", "maxp", "post", "vmtx"]
+)
+SPARSE_OTF_MASTER_TABLES = frozenset(["CFF ", "VORG", "head", "hmtx", "maxp", "vmtx"])
 
-UFO2FT_PREFIX = 'com.github.googlei18n.ufo2ft.'
-GLYPHS_PREFIX = 'com.schriftgestaltung.'
+UFO2FT_PREFIX = "com.github.googlei18n.ufo2ft."
+GLYPHS_PREFIX = "com.schriftgestaltung."
 
 USE_PRODUCTION_NAMES = UFO2FT_PREFIX + "useProductionNames"
 GLYPHS_DONT_USE_PRODUCTION_NAMES = GLYPHS_PREFIX + "Don't use Production Names"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fonttools[lxml,ufo]==3.35.0
+fonttools[lxml,ufo]==3.35.2
 defcon==0.6.0
 cu2qu==1.6.5
 compreffor==0.4.6.post1

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'pytest>=2.8',
     ],
     install_requires=[
-        "fonttools[ufo]>=3.35.0",
+        "fonttools[ufo]>=3.35.2",
         "defcon>=0.6.0",
         "cu2qu>=1.6.5",
         "compreffor>=0.4.5",

--- a/tests/outlineCompiler_test.py
+++ b/tests/outlineCompiler_test.py
@@ -941,6 +941,11 @@ def test_custom_layer_compilation_interpolatable_from_ds(designspace, inplace):
     sparse_tables = [tag for tag in master_ttfs[1].keys() if tag != "GlyphOrder"]
     assert SPARSE_TTF_MASTER_TABLES.issuperset(sparse_tables)
 
+    # sentinel value used by varLib to ignore the post table for this sparse
+    # master when building the MVAR table
+    assert master_ttfs[1]["post"].underlinePosition == -0x8000
+    assert master_ttfs[1]["post"].underlineThickness == -0x8000
+
 
 @pytest.mark.parametrize("inplace", [False, True], ids=["not inplace", "inplace"])
 def test_custom_layer_compilation_interpolatable_otf_from_ds(designspace, inplace):

--- a/tests/outlineCompiler_test.py
+++ b/tests/outlineCompiler_test.py
@@ -6,7 +6,12 @@ from fontTools import designspaceLib
 from ufo2ft.outlineCompiler import OutlineTTFCompiler, OutlineOTFCompiler
 from ufo2ft.fontInfoData import intListToNum
 from fontTools.ttLib.tables._g_l_y_f import USE_MY_METRICS
-from ufo2ft.constants import USE_PRODUCTION_NAMES, GLYPHS_DONT_USE_PRODUCTION_NAMES
+from ufo2ft.constants import (
+    USE_PRODUCTION_NAMES,
+    GLYPHS_DONT_USE_PRODUCTION_NAMES,
+    SPARSE_TTF_MASTER_TABLES,
+    SPARSE_OTF_MASTER_TABLES,
+)
 from ufo2ft import (
     compileTTF,
     compileOTF,
@@ -904,6 +909,9 @@ def test_custom_layer_compilation_interpolatable(layertestrgufo, layertestbdufo)
         "edotabove",
     ]
 
+    sparse_tables = [tag for tag in master_ttfs[1].keys() if tag != "GlyphOrder"]
+    assert SPARSE_TTF_MASTER_TABLES.issuperset(sparse_tables)
+
 
 @pytest.mark.parametrize("inplace", [False, True], ids=["not inplace", "inplace"])
 def test_custom_layer_compilation_interpolatable_from_ds(designspace, inplace):
@@ -930,6 +938,9 @@ def test_custom_layer_compilation_interpolatable_from_ds(designspace, inplace):
         "edotabove",
     ]
 
+    sparse_tables = [tag for tag in master_ttfs[1].keys() if tag != "GlyphOrder"]
+    assert SPARSE_TTF_MASTER_TABLES.issuperset(sparse_tables)
+
 
 @pytest.mark.parametrize("inplace", [False, True], ids=["not inplace", "inplace"])
 def test_custom_layer_compilation_interpolatable_otf_from_ds(designspace, inplace):
@@ -955,6 +966,9 @@ def test_custom_layer_compilation_interpolatable_otf_from_ds(designspace, inplac
         "dotabovecomb",
         "edotabove",
     ]
+
+    sparse_tables = [tag for tag in master_otfs[1].keys() if tag != "GlyphOrder"]
+    assert SPARSE_OTF_MASTER_TABLES.issuperset(sparse_tables)
 
 
 def test_compilation_from_ds_missing_source_font(designspace):


### PR DESCRIPTION
Fixes https://github.com/googlei18n/ufo2ft/issues/308

The OutlineCompiler classes gets a tables keyword argument that allows to customize the list of tables to be built. For the interpolatable sparse masters (those built from non-default layer) we only build (head, maxp, hmtx, loca, glyf, and post) for TTF, and (head, maxp, CFF and hmtx) for CFF-OTF.

There's still the issue about post which I summarized in this comment:
https://github.com/googlei18n/ufo2ft/issues/308#issuecomment-454079704

I'm leaning towards setting the underline values to 0x8000 or 0x7FFF to signal "do not use these for MVAR" to varLib.